### PR TITLE
Fix install.sh for MacOS

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -25,9 +25,17 @@ echo " [OK]"
 echo -n "Checking Docker..."
 # Check if /var/run/docker.sock exists
 if [ ! -S "/var/run/docker.sock" ]; then
-  echo " [FAIL]"
-  echo "Docker socket not found at /var/run/docker.sock. Please check your Docker installation and ensure docker is running."
-  exit 1
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    if ! docker info > /dev/null 2>&1; then
+      echo " [FAIL]"
+      echo "Docker is not running. Please start Docker Desktop."
+      exit 1
+    fi
+  else
+    echo " [FAIL]"
+    echo "Docker socket not found at /var/run/docker.sock. Please check your Docker installation and ensure docker is running."
+    exit 1
+  fi
 fi
 echo " [OK]"
 


### PR DESCRIPTION
The `install.sh` script fails for MacOS with following error even when the `docker` is running.
```bash
curl -sSL https://raw.githubusercontent.com/czhu12/canine/refs/heads/main/install/install.sh | bash
   _____            _            
  / ____|          (_)           
 | |     __ _ _ __  _ _ __   ___ 
 | |    / _` | '_ \| | '_ \ / _ \
 | |___| (_| | | | | | | | |  __/
  \_____\__,_|_| |_|_|_| |_|\___|

Cloning Canine...Cloning into '/Users/demo/.canine/src'... remote: Enumerating objects: 743, done.
remote: Counting objects: 100% (743/743), done.
remote: Compressing objects: 100% (645/645), done. remote: Total 743 (delta 65), reused 491 (delta 33), pack-reused 0 (from 0) Receiving objects: 100% (743/743), 5.15 MiB | 6.93 MiB/s, done. Resolving deltas: 100% (65/65), done.
 [OK]
Checking Docker... [FAIL]
Docker socket not found at /var/run/docker.sock. Please check your Docker installation and ensure docker is running.
```