### PR TITLE
fix: correct ufw restart to ufw reload

### DIFF
--- a/app/views/clusters/cluster_types/instructions/_k3s.html.erb
+++ b/app/views/clusters/cluster_types/instructions/_k3s.html.erb
@@ -24,7 +24,7 @@
       </div>
       <div class="text-sm mt-2">
         (You may have to run
-          <code class="cursor-pointer" data-controller="clipboard" data-clipboard-text="sudo ufw allow 6443 && sudo ufw restart">sudo ufw allow 6443 && sudo ufw restart</code>
+          <code class="cursor-pointer" data-controller="clipboard" data-clipboard-text="sudo ufw allow 6443 && sudo ufw reload">sudo ufw allow 6443 && sudo ufw reload</code>
           to allow outside connections to K3s.)
       </div>
 


### PR DESCRIPTION
## Fix: Correct UFW command in K3s instructions

Fixes a typo where `sudo ufw restart` (which possibly added as a typo) was replaced with equivalent command `reload`.

**Problem:** `ufw restart` is not a valid UFW command according to the [UFW man page](https://manpages.ubuntu.com/manpages/trusty/man8/ufw.8.html).

**Solution:** Replaced with equivalent command `reload` which is the proper command for applying firewall rule changes.

**Files changed:** `app/views/clusters/cluster_types/instructions/_k3s.html.erb`