### PR TITLE
CI: docker.yml: use checkout@v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Build with Docker Compose


### PR DESCRIPTION
This PR tries to avoid deprecation warnings about old GitHub Actions.