### PR TITLE
Add proxy-busy-buffers-size to nginx ingress configuration

### DIFF
--- a/resources/k8/scripts/install_nginx_ingress.sh
+++ b/resources/k8/scripts/install_nginx_ingress.sh
@@ -11,6 +11,7 @@ helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
   --set controller.config.proxy-body-size=0 \
   --set controller.config.proxy-buffer-size=16k \
   --set controller.config.proxy-buffers-number=8 \
+  --set controller.config.proxy-busy-buffers-size=32k \
   --set controller.config.proxy-read-timeout=3600 \
   --set controller.config.proxy-send-timeout=3600 \
   --set controller.config.h2-backend=true \


### PR DESCRIPTION
## Summary
- Added proxy-busy-buffers-size=32k configuration to the nginx ingress installation script

I ran into an issue getting setup on Digital Ocean where the nginx ingress was crashing because the busy buffer was smaller than buffer size. 

## Test plan
- [ ] Run the updated install_nginx_ingress.sh script on a test cluster
- [ ] Verify nginx ingress controller deploys successfully with the new configuration