### PR TITLE
Fix mobile navbar dropdown not navigating on tap

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["trigger"];
+
+  connect() {
+    this.closeOnClickOutside = this.closeOnClickOutside.bind(this);
+    document.addEventListener("click", this.closeOnClickOutside);
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this.closeOnClickOutside);
+  }
+
+  toggle(event) {
+    event.preventDefault();
+    this.element.classList.toggle("dropdown-open");
+  }
+
+  closeOnClickOutside(event) {
+    if (!this.element.contains(event.target)) {
+      this.element.classList.remove("dropdown-open");
+    }
+  }
+
+  close() {
+    this.element.classList.remove("dropdown-open");
+  }
+}

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,7 +5,7 @@
   </div>
 <% end %>
 
-<nav role="navigation" aria-label="Navbar" class="topbar-wrapper navbar z-10 border-b border-base-200 px-3" data-controller="toggle">
+<nav role="navigation" aria-label="Navbar" class="topbar-wrapper navbar z-10 border-b border-base-200 px-3">
   <%= render "shared/left_nav" %>
   <%= render "shared/right_nav" %>
 </nav>

--- a/app/views/shared/_right_nav.html.erb
+++ b/app/views/shared/_right_nav.html.erb
@@ -1,6 +1,6 @@
 <div class="ml-auto">
-  <div class="dropdown ml-auto dropdown-end dropdown-bottom">
-    <label tabindex="0" class="btn btn-ghost rounded-btn px-1.5 hover:bg-base-content/20">
+  <div class="dropdown ml-auto dropdown-end dropdown-bottom" data-controller="dropdown">
+    <label class="btn btn-ghost rounded-btn px-1.5 hover:bg-base-content/20" data-action="click->dropdown#toggle">
       <div aria-label="Avatar photo" class="avatar">
         <div class="mask mask-squircle" style="width: 30px; height: 30px">
           <%= image_tag avatar_path(current_user, size: 40) %>


### PR DESCRIPTION
The dropdown was using CSS focus-based visibility which caused links to not work on mobile - tapping a link would blur the dropdown first, hiding it before the click event could fire.

Replaced with a Stimulus controller that toggles dropdown-open class.