### PR TITLE
reconfigure deployment strategy

### DIFF
--- a/resources/k8/stateless/deployment.yaml
+++ b/resources/k8/stateless/deployment.yaml
@@ -11,8 +11,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 2
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: <%= service.name %>


### PR DESCRIPTION
setting maxunavailable: 1 and maxsurge: 2 results in single replica web instances experiencing downtime.

Adjusting to 0 / 1 will basically create 1 additional replica for single replica web instances, which could create memory pressure, but its probably worth the tradeoff because this is only enabled if healthcheck is turned on.