### PR TITLE
simplify auto-managed domain naming for single-service projects

### DIFF
--- a/app/actions/domains/attach_auto_managed_domain.rb
+++ b/app/actions/domains/attach_auto_managed_domain.rb
@@ -11,7 +11,13 @@ class Domains::AttachAutoManagedDomain
     next unless service.web_service?
     next if service.domains.exists?(auto_managed: true)
 
-    domain_name = "#{service.name}-#{service.project.slug}.oncanine.run"
+    project = service.project
+    public_web_services = project.services.web_service.where(allow_public_networking: true)
+    domain_name = if public_web_services.count <= 1
+      "#{project.slug}.oncanine.run"
+    else
+      "#{service.name}-#{project.slug}.oncanine.run"
+    end
 
     service.domains.create!(
       domain_name: domain_name,

--- a/spec/actions/domains/attach_auto_managed_domain_spec.rb
+++ b/spec/actions/domains/attach_auto_managed_domain_spec.rb
@@ -4,24 +4,38 @@ RSpec.describe Domains::AttachAutoManagedDomain do
   let(:project) { create(:project) }
 
   describe '.execute' do
-    context 'when auto dns is enabled and service is public web service' do
+    before do
+      allow(Dns::AutoSetupService).to receive(:enabled?).and_return(true)
+    end
+
+    context 'with a single public web service' do
       let(:service) { create(:service, project: project, allow_public_networking: true, service_type: :web_service) }
 
-      before do
-        allow(Dns::AutoSetupService).to receive(:enabled?).and_return(true)
-      end
-
-      it 'creates an auto-managed domain' do
+      it 'uses project-only domain name' do
         expect { described_class.execute(service: service) }.to change { service.domains.count }.by(1)
 
         domain = service.domains.last
         expect(domain.auto_managed).to be true
-        expect(domain.domain_name).to eq("#{service.name}-#{project.slug}.oncanine.run")
+        expect(domain.domain_name).to eq("#{project.slug}.oncanine.run")
       end
 
       it 'does not create duplicate auto-managed domains' do
         described_class.execute(service: service)
         expect { described_class.execute(service: service) }.not_to change { service.domains.count }
+      end
+    end
+
+    context 'with multiple public web services' do
+      let!(:first_service) { create(:service, name: "web", project: project, allow_public_networking: true, service_type: :web_service) }
+
+      before { described_class.execute(service: first_service) }
+
+      it 'uses service-project domain for second service and keeps the first unchanged' do
+        second_service = create(:service, name: "api", project: project, allow_public_networking: true, service_type: :web_service)
+        described_class.execute(service: second_service)
+
+        expect(second_service.domains.find_by(auto_managed: true).domain_name).to eq("api-#{project.slug}.oncanine.run")
+        expect(first_service.domains.find_by(auto_managed: true).reload.domain_name).to eq("#{project.slug}.oncanine.run")
       end
     end
 
@@ -38,10 +52,6 @@ RSpec.describe Domains::AttachAutoManagedDomain do
     end
 
     context 'when service is not public or not a web service' do
-      before do
-        allow(Dns::AutoSetupService).to receive(:enabled?).and_return(true)
-      end
-
       it 'does not create a domain for non-public services' do
         service = create(:service, project: project, allow_public_networking: false, service_type: :web_service)
         expect { described_class.execute(service: service) }.not_to change { Domain.count }


### PR DESCRIPTION
Use <project>.oncanine.run when there's only one public web service, and <service>-<project>.oncanine.run when there are multiple.