### PR TITLE
check for installed packages across all namespaces

### DIFF
--- a/app/models/cluster_package/installer/base.rb
+++ b/app/models/cluster_package/installer/base.rb
@@ -33,9 +33,7 @@ class ClusterPackage::Installer::Base
   end
 
   def installed?(kubectl)
-    namespace = Clusters::Install::DEFAULT_NAMESPACE
-    check_ns = definition["check_namespace"] || namespace
-    kubectl.(definition['check_command'].split + [ "-n", check_ns ])
+    kubectl.(definition['check_command'].split + [ "-A" ])
     true
   rescue Cli::CommandFailedError
     false

--- a/resources/helm/system_packages.yml
+++ b/resources/helm/system_packages.yml
@@ -89,7 +89,6 @@ packages:
     install_type: manifest
     manifest_path: resources/k8/shared/metrics_server.yaml
     check_command: get deployment metrics-server
-    check_namespace: kube-system
 
   - name: telepresence
     display_name: Telepresence


### PR DESCRIPTION
Instead of only checking canine-system, use -A flag to detect packages in any namespace to avoid duplicate installations.