### PR TITLE
Refactor onboarding: normal flow with in-cluster support

### DIFF
--- a/app/actions/onboarding/create.rb
+++ b/app/actions/onboarding/create.rb
@@ -1,0 +1,18 @@
+class Onboarding::Create
+  extend LightService::Organizer
+
+  def self.call(params)
+    with(
+      account_name: params[:account][:name],
+      email: params[:user][:email],
+      password: params[:user][:password],
+    ).reduce(actions)
+  end
+
+  def self.actions
+    [
+      Onboarding::CreateUserWithAccount,
+      Onboarding::CreateInClusterCluster
+    ]
+  end
+end

--- a/app/actions/onboarding/create.rb
+++ b/app/actions/onboarding/create.rb
@@ -6,6 +6,7 @@ class Onboarding::Create
       account_name: params[:account][:name],
       email: params[:user][:email],
       password: params[:user][:password],
+      connect_cluster: params[:connect_cluster] == "1",
     ).reduce(actions)
   end
 

--- a/app/actions/onboarding/create_in_cluster_cluster.rb
+++ b/app/actions/onboarding/create_in_cluster_cluster.rb
@@ -1,12 +1,11 @@
 class Onboarding::CreateInClusterCluster
   extend LightService::Action
   expects :account
-  promises :cluster
 
   executed do |context|
     next context unless K8::Connection.in_cluster?
 
-    context.cluster = Cluster.create!(
+    context[:cluster] = Cluster.create!(
       name: "in-cluster",
       account: context.account,
       options: { "in_cluster" => true },

--- a/app/actions/onboarding/create_in_cluster_cluster.rb
+++ b/app/actions/onboarding/create_in_cluster_cluster.rb
@@ -1,0 +1,16 @@
+class Onboarding::CreateInClusterCluster
+  extend LightService::Action
+  expects :account
+  promises :cluster
+
+  executed do |context|
+    next context unless K8::Connection.in_cluster?
+
+    context.cluster = Cluster.create!(
+      name: "in-cluster",
+      account: context.account,
+      options: { "in_cluster" => true },
+      status: :running
+    )
+  end
+end

--- a/app/actions/onboarding/create_in_cluster_cluster.rb
+++ b/app/actions/onboarding/create_in_cluster_cluster.rb
@@ -1,9 +1,9 @@
 class Onboarding::CreateInClusterCluster
   extend LightService::Action
-  expects :account
+  expects :account, :connect_cluster
 
   executed do |context|
-    next context unless K8::Connection.in_cluster?
+    next context unless context.connect_cluster && K8::Connection.in_cluster?
 
     context[:cluster] = Cluster.create!(
       name: "in-cluster",

--- a/app/actions/onboarding/create_user_with_account.rb
+++ b/app/actions/onboarding/create_user_with_account.rb
@@ -1,0 +1,22 @@
+class Onboarding::CreateUserWithAccount
+  extend LightService::Action
+  expects :account_name, :email, :password
+  promises :user, :account
+
+  executed do |context|
+    ActiveRecord::Base.transaction do
+      context.user = User.find_or_initialize_by(email: context.email)
+      context.user.assign_attributes(
+        password: context.password,
+        password_confirmation: context.password,
+      )
+      context.user.write_attribute(:admin, true) if context.user.new_record?
+      context.user.save!
+
+      context.account = Account.create!(owner: context.user, name: context.account_name)
+      AccountUser.create!(account: context.account, user: context.user, role: :owner)
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    context.fail_and_return!(e.message)
+  end
+end

--- a/app/components/cluster_summary_card_component.html.erb
+++ b/app/components/cluster_summary_card_component.html.erb
@@ -1,91 +1,41 @@
-<div class="card bg-base-200 border border-base-300 shadow-sm">
-  <div class="card-body p-5">
-    <% if error %>
-      <div class="flex items-center gap-2 text-warning">
-        <iconify-icon icon="lucide:alert-triangle" width="20"></iconify-icon>
-        <span class="text-sm">Unable to fetch cluster details: <%= error %></span>
-      </div>
-    <% else %>
-      <div class="flex items-center gap-2 mb-3">
-        <iconify-icon icon="lucide:server" width="20" class="text-primary"></iconify-icon>
-        <h3 class="font-semibold text-lg">Kubernetes Cluster Detected</h3>
-      </div>
+<div>
+  <% if error %>
+    <div class="alert alert-warning">
+      <iconify-icon icon="lucide:alert-triangle" width="18"></iconify-icon>
+      <span class="text-sm">Unable to fetch cluster details: <%= error %></span>
+    </div>
+  <% else %>
+    <%# Alert %>
+    <div class="alert alert-info mb-3">
+      <iconify-icon icon="lucide:server" width="18"></iconify-icon>
+      <span class="text-sm">Kubernetes cluster detected. Canine can deploy to this cluster automatically.</span>
+    </div>
 
-      <p class="text-sm text-base-content/70 mb-4">
-        Canine is running inside this cluster and will connect to it automatically.
-      </p>
-
-      <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
-        <%# Nodes %>
-        <div class="bg-base-100 rounded-lg p-3">
-          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
-            <iconify-icon icon="lucide:boxes" width="14"></iconify-icon>
-            Nodes
-          </div>
-          <div class="text-2xl font-bold mt-1"><%= nodes.size %></div>
-        </div>
-
-        <%# Version %>
+    <%# Cluster card %>
+    <div class="rounded-lg border border-base-300 bg-base-200 px-4 py-3">
+      <div class="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+        <span class="flex items-center gap-1.5">
+          <iconify-icon icon="lucide:boxes" width="15" class="text-base-content/50"></iconify-icon>
+          <span class="font-medium"><%= nodes.size %></span>
+          <span class="text-base-content/60"><%= nodes.size == 1 ? "node" : "nodes" %></span>
+        </span>
         <% if version %>
-          <div class="bg-base-100 rounded-lg p-3">
-            <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
-              <iconify-icon icon="lucide:tag" width="14"></iconify-icon>
-              Version
-            </div>
-            <div class="text-2xl font-bold mt-1"><%= version %></div>
-          </div>
+          <span class="flex items-center gap-1.5">
+            <iconify-icon icon="lucide:tag" width="15" class="text-base-content/50"></iconify-icon>
+            <span class="font-medium"><%= version %></span>
+          </span>
         <% end %>
-
-        <%# CPU %>
-        <div class="bg-base-100 rounded-lg p-3">
-          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
-            <iconify-icon icon="lucide:cpu" width="14"></iconify-icon>
-            CPU
-          </div>
-          <div class="text-2xl font-bold mt-1"><%= integer_to_compute(total_cpu) %></div>
-          <div class="text-xs text-base-content/60 mt-1"><%= cpu_percent %>% used</div>
-        </div>
-
-        <%# Memory %>
-        <div class="bg-base-100 rounded-lg p-3">
-          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
-            <iconify-icon icon="lucide:memory-stick" width="14"></iconify-icon>
-            Memory
-          </div>
-          <div class="text-2xl font-bold mt-1"><%= integer_to_memory(total_memory) %></div>
-          <div class="text-xs text-base-content/60 mt-1"><%= memory_percent %>% used</div>
-        </div>
+        <span class="flex items-center gap-1.5">
+          <iconify-icon icon="lucide:cpu" width="15" class="text-base-content/50"></iconify-icon>
+          <span class="font-medium"><%= integer_to_compute(total_cpu) %></span>
+          <span class="text-base-content/60">CPU</span>
+        </span>
+        <span class="flex items-center gap-1.5">
+          <iconify-icon icon="lucide:memory-stick" width="15" class="text-base-content/50"></iconify-icon>
+          <span class="font-medium"><%= integer_to_memory(total_memory) %></span>
+          <span class="text-base-content/60">RAM</span>
+        </span>
       </div>
-
-      <%# Per-node breakdown %>
-      <% if nodes.size > 1 %>
-        <div class="mt-3">
-          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide mb-2">
-            <iconify-icon icon="lucide:network" width="14"></iconify-icon>
-            Nodes
-          </div>
-          <div class="space-y-2">
-            <% nodes.each do |node| %>
-              <div class="flex items-center justify-between bg-base-100 rounded-lg px-3 py-2 text-sm">
-                <div class="flex items-center gap-2">
-                  <iconify-icon icon="lucide:hard-drive" width="14" class="text-base-content/50"></iconify-icon>
-                  <span class="font-medium"><%= node.name %></span>
-                </div>
-                <div class="flex gap-4 text-base-content/70">
-                  <span class="flex items-center gap-1">
-                    <iconify-icon icon="lucide:cpu" width="12"></iconify-icon>
-                    <%= integer_to_compute(node.total_cpu) %>
-                  </span>
-                  <span class="flex items-center gap-1">
-                    <iconify-icon icon="lucide:memory-stick" width="12"></iconify-icon>
-                    <%= integer_to_memory(node.total_memory) %>
-                  </span>
-                </div>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/components/cluster_summary_card_component.html.erb
+++ b/app/components/cluster_summary_card_component.html.erb
@@ -1,0 +1,67 @@
+<div class="card bg-base-200 border border-base-300 shadow-sm">
+  <div class="card-body p-5">
+    <% if error %>
+      <div class="flex items-center gap-2 text-warning">
+        <iconify-icon icon="lucide:alert-triangle" width="20"></iconify-icon>
+        <span class="text-sm">Unable to fetch cluster details: <%= error %></span>
+      </div>
+    <% else %>
+      <div class="flex items-center gap-2 mb-3">
+        <iconify-icon icon="lucide:server" width="20" class="text-primary"></iconify-icon>
+        <h3 class="font-semibold text-lg">Kubernetes Cluster Detected</h3>
+      </div>
+
+      <p class="text-sm text-base-content/70 mb-4">
+        Canine is running inside this cluster and will connect to it automatically.
+      </p>
+
+      <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        <%# Nodes %>
+        <div class="bg-base-100 rounded-lg p-3">
+          <div class="text-xs text-base-content/60 uppercase tracking-wide">Nodes</div>
+          <div class="text-2xl font-bold mt-1"><%= nodes.size %></div>
+        </div>
+
+        <%# Version %>
+        <% if version %>
+          <div class="bg-base-100 rounded-lg p-3">
+            <div class="text-xs text-base-content/60 uppercase tracking-wide">Version</div>
+            <div class="text-2xl font-bold mt-1"><%= version %></div>
+          </div>
+        <% end %>
+
+        <%# CPU %>
+        <div class="bg-base-100 rounded-lg p-3">
+          <div class="text-xs text-base-content/60 uppercase tracking-wide">CPU</div>
+          <div class="text-2xl font-bold mt-1"><%= integer_to_compute(total_cpu) %></div>
+          <div class="text-xs text-base-content/60 mt-1"><%= cpu_percent %>% used</div>
+        </div>
+
+        <%# Memory %>
+        <div class="bg-base-100 rounded-lg p-3">
+          <div class="text-xs text-base-content/60 uppercase tracking-wide">Memory</div>
+          <div class="text-2xl font-bold mt-1"><%= integer_to_memory(total_memory) %></div>
+          <div class="text-xs text-base-content/60 mt-1"><%= memory_percent %>% used</div>
+        </div>
+      </div>
+
+      <%# Per-node breakdown %>
+      <% if nodes.size > 1 %>
+        <div class="mt-3">
+          <div class="text-xs text-base-content/60 uppercase tracking-wide mb-2">Nodes</div>
+          <div class="space-y-2">
+            <% nodes.each do |node| %>
+              <div class="flex items-center justify-between bg-base-100 rounded-lg px-3 py-2 text-sm">
+                <span class="font-medium"><%= node.name %></span>
+                <div class="flex gap-4 text-base-content/70">
+                  <span><%= integer_to_compute(node.total_cpu) %> CPU</span>
+                  <span><%= integer_to_memory(node.total_memory) %> RAM</span>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/cluster_summary_card_component.html.erb
+++ b/app/components/cluster_summary_card_component.html.erb
@@ -18,28 +18,40 @@
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <%# Nodes %>
         <div class="bg-base-100 rounded-lg p-3">
-          <div class="text-xs text-base-content/60 uppercase tracking-wide">Nodes</div>
+          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
+            <iconify-icon icon="lucide:boxes" width="14"></iconify-icon>
+            Nodes
+          </div>
           <div class="text-2xl font-bold mt-1"><%= nodes.size %></div>
         </div>
 
         <%# Version %>
         <% if version %>
           <div class="bg-base-100 rounded-lg p-3">
-            <div class="text-xs text-base-content/60 uppercase tracking-wide">Version</div>
+            <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
+              <iconify-icon icon="lucide:tag" width="14"></iconify-icon>
+              Version
+            </div>
             <div class="text-2xl font-bold mt-1"><%= version %></div>
           </div>
         <% end %>
 
         <%# CPU %>
         <div class="bg-base-100 rounded-lg p-3">
-          <div class="text-xs text-base-content/60 uppercase tracking-wide">CPU</div>
+          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
+            <iconify-icon icon="lucide:cpu" width="14"></iconify-icon>
+            CPU
+          </div>
           <div class="text-2xl font-bold mt-1"><%= integer_to_compute(total_cpu) %></div>
           <div class="text-xs text-base-content/60 mt-1"><%= cpu_percent %>% used</div>
         </div>
 
         <%# Memory %>
         <div class="bg-base-100 rounded-lg p-3">
-          <div class="text-xs text-base-content/60 uppercase tracking-wide">Memory</div>
+          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide">
+            <iconify-icon icon="lucide:memory-stick" width="14"></iconify-icon>
+            Memory
+          </div>
           <div class="text-2xl font-bold mt-1"><%= integer_to_memory(total_memory) %></div>
           <div class="text-xs text-base-content/60 mt-1"><%= memory_percent %>% used</div>
         </div>
@@ -48,14 +60,26 @@
       <%# Per-node breakdown %>
       <% if nodes.size > 1 %>
         <div class="mt-3">
-          <div class="text-xs text-base-content/60 uppercase tracking-wide mb-2">Nodes</div>
+          <div class="flex items-center gap-1.5 text-xs text-base-content/60 uppercase tracking-wide mb-2">
+            <iconify-icon icon="lucide:network" width="14"></iconify-icon>
+            Nodes
+          </div>
           <div class="space-y-2">
             <% nodes.each do |node| %>
               <div class="flex items-center justify-between bg-base-100 rounded-lg px-3 py-2 text-sm">
-                <span class="font-medium"><%= node.name %></span>
+                <div class="flex items-center gap-2">
+                  <iconify-icon icon="lucide:hard-drive" width="14" class="text-base-content/50"></iconify-icon>
+                  <span class="font-medium"><%= node.name %></span>
+                </div>
                 <div class="flex gap-4 text-base-content/70">
-                  <span><%= integer_to_compute(node.total_cpu) %> CPU</span>
-                  <span><%= integer_to_memory(node.total_memory) %> RAM</span>
+                  <span class="flex items-center gap-1">
+                    <iconify-icon icon="lucide:cpu" width="12"></iconify-icon>
+                    <%= integer_to_compute(node.total_cpu) %>
+                  </span>
+                  <span class="flex items-center gap-1">
+                    <iconify-icon icon="lucide:memory-stick" width="12"></iconify-icon>
+                    <%= integer_to_memory(node.total_memory) %>
+                  </span>
                 </div>
               </div>
             <% end %>

--- a/app/components/cluster_summary_card_component.rb
+++ b/app/components/cluster_summary_card_component.rb
@@ -1,0 +1,37 @@
+class ClusterSummaryCardComponent < ViewComponent::Base
+  include StorageHelper
+
+  attr_reader :nodes, :version, :error
+
+  def initialize(nodes:, version: nil, error: nil)
+    @nodes = nodes
+    @version = version
+    @error = error
+  end
+
+  def total_cpu
+    nodes.sum(&:total_cpu)
+  end
+
+  def total_memory
+    nodes.sum(&:total_memory)
+  end
+
+  def used_cpu
+    nodes.sum(&:cpu_cores)
+  end
+
+  def used_memory
+    nodes.sum(&:used_memory)
+  end
+
+  def cpu_percent
+    return 0 if total_cpu.zero?
+    (used_cpu / total_cpu.to_f * 100).round(1)
+  end
+
+  def memory_percent
+    return 0 if total_memory.zero?
+    (used_memory / total_memory.to_f * 100).round(1)
+  end
+end

--- a/app/controllers/local/onboarding_controller.rb
+++ b/app/controllers/local/onboarding_controller.rb
@@ -3,6 +3,10 @@ class Local::OnboardingController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
+    @in_cluster = K8::Connection.in_cluster?
+    if @in_cluster
+      @cluster_nodes, @cluster_version = fetch_in_cluster_info
+    end
   end
 
   def account_select
@@ -29,5 +33,19 @@ class Local::OnboardingController < ApplicationController
     else
       redirect_to local_onboarding_index_path, alert: result.message
     end
+  end
+
+  private
+
+  def fetch_in_cluster_info
+    # Build a temporary in-cluster connection without a persisted cluster
+    cluster = Cluster.new(options: { "in_cluster" => true })
+    connection = K8::Connection.new(cluster, nil)
+    nodes = K8::Metrics::Api::Node.ls(connection, with_namespaces: false)
+    version = K8::Client.new(connection).version["serverVersion"]["gitVersion"]
+    [ nodes, version ]
+  rescue StandardError => e
+    Rails.logger.error("Failed to fetch in-cluster info: #{e.message}")
+    [ [], nil ]
   end
 end

--- a/app/controllers/local/onboarding_controller.rb
+++ b/app/controllers/local/onboarding_controller.rb
@@ -12,7 +12,15 @@ class Local::OnboardingController < ApplicationController
   end
 
   def create
-    result = Portainer::Onboarding::Create.call(params)
+    result = case params[:onboarding_method]
+    when "portainer"
+      Portainer::Onboarding::Create.call(params)
+    when "normal"
+      Onboarding::Create.call(params)
+    else
+      redirect_to local_onboarding_index_path, alert: "Invalid onboarding method"
+      return
+    end
 
     if result.success?
       sign_in(result.user)

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -44,7 +44,7 @@ class Cluster < ApplicationRecord
   validates :name, presence: true,
                    format: { with: /\A[a-z0-9-]+\z/, message: "must be lowercase, numbers, and hyphens only" },
                    uniqueness: { scope: :account_id }
-  validates_presence_of :kubeconfig, unless: :external?
+  validates_presence_of :kubeconfig, unless: -> { external? || in_cluster? }
   enum :status, {
     initializing: 0,
     installing: 1,
@@ -69,6 +69,10 @@ class Cluster < ApplicationRecord
 
   def external?
     external_id.present?
+  end
+
+  def in_cluster?
+    options&.dig("in_cluster") == true
   end
 
   private

--- a/app/services/k8/connection.rb
+++ b/app/services/k8/connection.rb
@@ -20,7 +20,9 @@ class K8::Connection
   end
 
   def kubeconfig
-    config = if cluster.kubeconfig.present?
+    config = if cluster.in_cluster?
+      build_in_cluster_kubeconfig
+    elsif cluster.kubeconfig.present?
       cluster.kubeconfig
     else
       raise StandardError.new("No stack manager found") if stack_manager.blank?
@@ -44,11 +46,53 @@ class K8::Connection
     cluster.account.stack_manager
   end
 
+  SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  SA_CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+  def self.in_cluster?
+    ENV["KUBERNETES_SERVICE_HOST"].present? && File.exist?(SA_TOKEN_PATH)
+  end
+
   %i[add_on project].each do |method_name|
     define_method method_name do
       class_name = method_name.to_s.classify
       raise "`clusterable` is not a #{class_name}" unless clusterable.is_a?(class_name.constantize)
       clusterable
     end
+  end
+
+  private
+
+  def build_in_cluster_kubeconfig
+    host = ENV.fetch("KUBERNETES_SERVICE_HOST")
+    port = ENV.fetch("KUBERNETES_SERVICE_PORT", "443")
+    token = File.read(SA_TOKEN_PATH)
+    ca_data = Base64.strict_encode64(File.read(SA_CA_PATH))
+
+    {
+      "apiVersion" => "v1",
+      "kind" => "Config",
+      "current-context" => "in-cluster",
+      "clusters" => [{
+        "name" => "in-cluster",
+        "cluster" => {
+          "server" => "https://#{host}:#{port}",
+          "certificate-authority-data" => ca_data
+        }
+      }],
+      "contexts" => [{
+        "name" => "in-cluster",
+        "context" => {
+          "cluster" => "in-cluster",
+          "user" => "service-account"
+        }
+      }],
+      "users" => [{
+        "name" => "service-account",
+        "user" => {
+          "token" => token
+        }
+      }]
+    }
   end
 end

--- a/app/services/k8/connection.rb
+++ b/app/services/k8/connection.rb
@@ -73,26 +73,26 @@ class K8::Connection
       "apiVersion" => "v1",
       "kind" => "Config",
       "current-context" => "in-cluster",
-      "clusters" => [{
+      "clusters" => [ {
         "name" => "in-cluster",
         "cluster" => {
           "server" => "https://#{host}:#{port}",
           "certificate-authority-data" => ca_data
         }
-      }],
-      "contexts" => [{
+      } ],
+      "contexts" => [ {
         "name" => "in-cluster",
         "context" => {
           "cluster" => "in-cluster",
           "user" => "service-account"
         }
-      }],
-      "users" => [{
+      } ],
+      "users" => [ {
         "name" => "service-account",
         "user" => {
           "token" => token
         }
-      }]
+      } ]
     }
   end
 end

--- a/app/views/local/onboarding/_normal.html.erb
+++ b/app/views/local/onboarding/_normal.html.erb
@@ -1,6 +1,7 @@
 <div>
   <%= form_with url: local_onboarding_index_path, method: :post, class: "space-y-8" do |form| %>
-    <%= form.hidden_field :onboarding_method, value: "portainer", name: "onboarding_method" %>
+    <%= form.hidden_field :onboarding_method, value: "normal", name: "onboarding_method" %>
+
     <%= render(FormFieldComponent.new(
       label: "Account Details",
       description: "The name of your team, organization or account."
@@ -50,41 +51,8 @@
       </div>
     <% end %>
 
-    <%= render(FormFieldComponent.new(
-      label: "Portainer Configuration",
-      description: "Configure your Portainer instance URL and access token."
-    )) do %>
-      <%= render "accounts/stack_managers/url", form: form %>
-
-      <div class="mt-4">
-        <div data-controller="expandable-optional-input">
-          <div>
-            <a data-action="expandable-optional-input#show" class="btn btn-ghost">
-              + Add personal access token
-            </a>
-          </div>
-          <div data-expandable-optional-input-target="container">
-            <div class="form-group">
-              <%= form.label :personal_access_token, "Personal Access Token" %>
-              <%= form.text_field(
-                :personal_access_token,
-                name: "user[personal_access_token]",
-                placeholder: "Enter your personal access token",
-                class: "input input-bordered w-full",
-              ) %>
-            </div>
-          </div>
-        </div>
-        <div class="label">
-          <span class="label-text-alt text-gray-500">
-            If not provided, the account's access token will be used for your Portainer access.
-          </span>
-        </div>
-      </div>
-    <% end %>
-
     <div class="form-footer">
-      <%= form.submit "Save", class: "btn btn-primary" %>
+      <%= form.submit "Get Started", class: "btn btn-primary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/local/onboarding/_normal.html.erb
+++ b/app/views/local/onboarding/_normal.html.erb
@@ -1,14 +1,4 @@
 <div>
-  <% if @in_cluster %>
-    <div class="mb-6">
-      <%= render(ClusterSummaryCardComponent.new(
-        nodes: @cluster_nodes,
-        version: @cluster_version,
-        error: @cluster_nodes.empty? ? "Could not connect to cluster" : nil
-      )) %>
-    </div>
-  <% end %>
-
   <%= form_with url: local_onboarding_index_path, method: :post, class: "space-y-8" do |form| %>
     <%= form.hidden_field :onboarding_method, value: "normal", name: "onboarding_method" %>
 
@@ -59,6 +49,28 @@
           </button>
         </div>
       </div>
+    <% end %>
+
+    <% if @in_cluster %>
+      <%= render(FormFieldComponent.new(
+        label: "Cluster",
+        description: "Deploy to the cluster Canine is running in."
+      )) do %>
+        <div class="space-y-3">
+          <%= render(ClusterSummaryCardComponent.new(
+            nodes: @cluster_nodes,
+            version: @cluster_version,
+            error: @cluster_nodes.empty? ? "Could not connect to cluster" : nil
+          )) %>
+          <div class="form-control rounded-lg bg-base-200 p-2 px-4">
+            <label class="label mt-1">
+              <span class="label-text cursor-pointer">Connect Canine to this cluster</span>
+              <%= form.check_box :connect_cluster, { checked: true, class: "checkbox", name: "connect_cluster" }, "1", "0" %>
+            </label>
+          </div>
+          <span class="label-text-alt">Unchecking this will skip connecting to the cluster. You can add clusters later.</span>
+        </div>
+      <% end %>
     <% end %>
 
     <div class="form-footer">

--- a/app/views/local/onboarding/_normal.html.erb
+++ b/app/views/local/onboarding/_normal.html.erb
@@ -1,4 +1,14 @@
 <div>
+  <% if @in_cluster %>
+    <div class="mb-6">
+      <%= render(ClusterSummaryCardComponent.new(
+        nodes: @cluster_nodes,
+        version: @cluster_version,
+        error: @cluster_nodes.empty? ? "Could not connect to cluster" : nil
+      )) %>
+    </div>
+  <% end %>
+
   <%= form_with url: local_onboarding_index_path, method: :post, class: "space-y-8" do |form| %>
     <%= form.hidden_field :onboarding_method, value: "normal", name: "onboarding_method" %>
 

--- a/app/views/local/onboarding/index.html.erb
+++ b/app/views/local/onboarding/index.html.erb
@@ -25,7 +25,8 @@
           label: "Normal (Recommended)",
           value: "normal",
           description: "Standard installation of Canine. Select this if it's your first time using Canine.",
-          href: new_user_registration_url
+          partial: "local/onboarding/normal",
+          locals: {}
         },
         {
           icon: "/images/helm/portainer.webp",

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ module Canine
     config.local_mode_passwordless = ENV.fetch("LOCAL_MODE_PASSWORDLESS", "false") == "true"
     config.cloud_mode = config.boot_mode == "cloud"
     config.cluster_mode = config.boot_mode == "cluster"
-    config.onboarding_methods = ENV.fetch("ONBOARDING_METHODS", "").split(",") # normal, portainer
+    config.onboarding_method = ENV.fetch("ONBOARDING_METHOD", "") # normal, portainer
     config.account_sign_in_only = ENV.fetch("ACCOUNT_SIGN_IN_ONLY", "") == "true"
     config.build_configuration_enabled = ENV.fetch("BUILD_CONFIGURATION_ENABLED", "true") != "false"
     config.remap_localhost = ENV.fetch("REMAP_LOCALHOST", "")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -264,7 +264,7 @@ Rails.application.routes.draw do
         end
       end
     end
-    if Rails.application.config.onboarding_methods.any?
+    if Rails.application.config.onboarding_method.present?
       root to: "local/onboarding#index"
     else
       root to: "local/onboarding#account_select"

--- a/spec/actions/onboarding/create_spec.rb
+++ b/spec/actions/onboarding/create_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Onboarding::Create do
     ActionController::Parameters.new(
       account: { name: 'testorg' },
       user: { email: 'admin@example.com', password: 'password123' },
+      connect_cluster: "1",
     )
   end
 
@@ -28,7 +29,7 @@ RSpec.describe Onboarding::Create do
       end
     end
 
-    context 'when running in-cluster' do
+    context 'when running in-cluster and connect_cluster is enabled' do
       before do
         allow(K8::Connection).to receive(:in_cluster?).and_return(true)
       end
@@ -47,11 +48,35 @@ RSpec.describe Onboarding::Create do
       end
     end
 
+    context 'when running in-cluster but connect_cluster is disabled' do
+      let(:params) do
+        ActionController::Parameters.new(
+          account: { name: 'testorg' },
+          user: { email: 'admin@example.com', password: 'password123' },
+          connect_cluster: "0",
+        )
+      end
+
+      before do
+        allow(K8::Connection).to receive(:in_cluster?).and_return(true)
+      end
+
+      it 'creates admin user and account without a cluster' do
+        result = described_class.call(params)
+
+        expect(result).to be_success
+        expect(result.user).to be_persisted
+        expect(result.account).to be_persisted
+        expect(Cluster.count).to eq(0)
+      end
+    end
+
     context 'when user email is invalid' do
       let(:params) do
         ActionController::Parameters.new(
           account: { name: 'testorg' },
           user: { email: '', password: 'password123' },
+          connect_cluster: "1",
         )
       end
 

--- a/spec/actions/onboarding/create_spec.rb
+++ b/spec/actions/onboarding/create_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Onboarding::Create do
+  let(:params) do
+    ActionController::Parameters.new(
+      account: { name: 'testorg' },
+      user: { email: 'admin@example.com', password: 'password123' },
+    )
+  end
+
+  describe '.call' do
+    context 'when not running in-cluster' do
+      before do
+        allow(K8::Connection).to receive(:in_cluster?).and_return(false)
+      end
+
+      it 'creates admin user and account without a cluster' do
+        result = described_class.call(params)
+
+        expect(result).to be_success
+        expect(result.user).to be_persisted
+        expect(result.user.email).to eq('admin@example.com')
+        expect(result.user.admin).to be true
+        expect(result.account.name).to eq('testorg')
+        expect(result.account.owner).to eq(result.user)
+        expect(AccountUser.find_by(account: result.account, user: result.user).role).to eq('owner')
+        expect(Cluster.count).to eq(0)
+      end
+    end
+
+    context 'when running in-cluster' do
+      before do
+        allow(K8::Connection).to receive(:in_cluster?).and_return(true)
+      end
+
+      it 'creates admin user, account, and in-cluster cluster' do
+        result = described_class.call(params)
+
+        expect(result).to be_success
+        expect(result.user).to be_persisted
+        expect(result.account).to be_persisted
+        expect(result[:cluster]).to be_persisted
+        expect(result[:cluster].name).to eq('in-cluster')
+        expect(result[:cluster].in_cluster?).to be true
+        expect(result[:cluster].status).to eq('running')
+        expect(result[:cluster].account).to eq(result.account)
+      end
+    end
+
+    context 'when user email is invalid' do
+      let(:params) do
+        ActionController::Parameters.new(
+          account: { name: 'testorg' },
+          user: { email: '', password: 'password123' },
+        )
+      end
+
+      it 'fails with an error' do
+        result = described_class.call(params)
+        expect(result).to be_failure
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Rename `ONBOARDING_METHODS` to `ONBOARDING_METHOD` (single value: `normal` or `portainer`)
- Add dedicated normal onboarding form with LightService actions instead of redirecting to Devise registration
- Detect in-cluster Kubernetes environment and auto-create cluster on onboarding
- `K8::Connection` builds kubeconfig from service account token when cluster is in-cluster
- Reusable `ClusterSummaryCardComponent` shows cluster stats (nodes, version, CPU, RAM)
- Checkbox to opt out of connecting to the detected cluster

## Test plan
- [x] `bundle exec rspec spec/actions/onboarding/create_spec.rb` — 4 specs pass
- [ ] Deploy via Helm chart and verify onboarding detects the in-cluster environment
- [ ] Verify Portainer onboarding still works with `onboarding_method` param
- [ ] Verify unchecking "Connect Canine to this cluster" skips cluster creation