### PR TITLE
Fix onboarding: use kubectl get nodes instead of top nodes

### DIFF
--- a/app/controllers/local/onboarding_controller.rb
+++ b/app/controllers/local/onboarding_controller.rb
@@ -38,10 +38,23 @@ class Local::OnboardingController < ApplicationController
   private
 
   def fetch_in_cluster_info
-    # Build a temporary in-cluster connection without a persisted cluster
     cluster = Cluster.new(options: { "in_cluster" => true })
     connection = K8::Connection.new(cluster, nil)
-    nodes = K8::Metrics::Api::Node.ls(connection, with_namespaces: false)
+    kubectl = K8::Kubectl.new(connection)
+
+    # Use kubectl get nodes (doesn't require metrics-server)
+    raw = YAML.safe_load(kubectl.call(%w[get nodes -o yaml]))
+    nodes = (raw["items"] || []).map do |item|
+      allocatable = item.dig("status", "allocatable") || {}
+      K8::Metrics::Api::Node.new(
+        name: item.dig("metadata", "name"),
+        cpu_cores: 0,
+        total_cpu: K8::Metrics::Api::Node.compute_to_integer(allocatable["cpu"] || "0"),
+        used_memory: 0,
+        total_memory: K8::Metrics::Api::Node.memory_to_integer(allocatable["memory"] || "0")
+      )
+    end
+
     version = K8::Client.new(connection).version["serverVersion"]["gitVersion"]
     [ nodes, version ]
   rescue StandardError => e


### PR DESCRIPTION
## Summary
- `kubectl top nodes` requires metrics-server which may not be installed
- Switch to `kubectl get nodes -o yaml` to read allocatable CPU/memory
- Fixes "Unable to fetch cluster details" error on clusters without metrics-server

## Test plan
- [ ] Deploy to cluster without metrics-server and verify cluster card shows node info