### PR TITLE
Sync system packages after in-cluster onboarding

### DIFF
--- a/app/actions/onboarding/create_in_cluster_cluster.rb
+++ b/app/actions/onboarding/create_in_cluster_cluster.rb
@@ -1,6 +1,6 @@
 class Onboarding::CreateInClusterCluster
   extend LightService::Action
-  expects :account, :connect_cluster
+  expects :account, :user, :connect_cluster
 
   executed do |context|
     next context unless context.connect_cluster && K8::Connection.in_cluster?
@@ -11,5 +11,8 @@ class Onboarding::CreateInClusterCluster
       options: { "in_cluster" => true },
       status: :running
     )
+
+    # Sync packages to detect what's already installed (e.g. traefik, cert-manager from helm chart)
+    Clusters::SyncPackages.execute(cluster: context[:cluster], user: context.user)
   end
 end

--- a/spec/actions/onboarding/create_spec.rb
+++ b/spec/actions/onboarding/create_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Onboarding::Create do
     context 'when running in-cluster and connect_cluster is enabled' do
       before do
         allow(K8::Connection).to receive(:in_cluster?).and_return(true)
+        allow(Clusters::SyncPackages).to receive(:execute).and_return(LightService::Context.make)
       end
 
       it 'creates admin user, account, and in-cluster cluster' do


### PR DESCRIPTION
## Summary
- After creating the in-cluster cluster during onboarding, run `Clusters::SyncPackages` to detect already-installed components (traefik, cert-manager, metrics-server, etc.)
- This ensures the cluster packages UI reflects what's actually running rather than showing everything as uninstalled

## Test plan
- [x] `bundle exec rspec spec/actions/onboarding/create_spec.rb` — 4 specs pass
- [ ] Onboard on a helm-deployed cluster and verify installed packages are detected