### PR TITLE
Use InstallJob for in-cluster onboarding

### DIFF
--- a/app/actions/onboarding/create_in_cluster_cluster.rb
+++ b/app/actions/onboarding/create_in_cluster_cluster.rb
@@ -12,7 +12,6 @@ class Onboarding::CreateInClusterCluster
       status: :running
     )
 
-    # Sync packages to detect what's already installed (e.g. traefik, cert-manager from helm chart)
-    Clusters::SyncPackages.execute(cluster: context[:cluster], user: context.user)
+    Clusters::InstallJob.perform_later(context[:cluster], context.user)
   end
 end

--- a/spec/actions/onboarding/create_spec.rb
+++ b/spec/actions/onboarding/create_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Onboarding::Create do
     context 'when running in-cluster and connect_cluster is enabled' do
       before do
         allow(K8::Connection).to receive(:in_cluster?).and_return(true)
-        allow(Clusters::SyncPackages).to receive(:execute).and_return(LightService::Context.make)
+        allow(Clusters::InstallJob).to receive(:perform_later)
       end
 
       it 'creates admin user, account, and in-cluster cluster' do


### PR DESCRIPTION
## Summary
- Replace `Clusters::SyncPackages` with `Clusters::InstallJob.perform_later` after creating the in-cluster cluster
- This runs the full install flow: creates `canine-system` namespace and installs default packages (skipping already-installed ones)

## Test plan
- [x] `bundle exec rspec spec/actions/onboarding/create_spec.rb` — 4 specs pass