### PR TITLE
Fix package installed check to work across all namespaces

### DIFF
--- a/app/models/cluster_package/installer/base.rb
+++ b/app/models/cluster_package/installer/base.rb
@@ -33,8 +33,13 @@ class ClusterPackage::Installer::Base
   end
 
   def installed?(kubectl)
-    kubectl.(definition['check_command'].split + [ "-A" ])
-    true
+    parts = definition['check_command'].split
+    verb = parts[0]
+    resource_type = parts[1]
+    resource_name = parts[2]
+
+    output = kubectl.(%W[#{verb} #{resource_type} -A --no-headers])
+    output.to_s.split("\n").any? { |line| line.split(/\s+/).any? { |col| col.include?(resource_name) } }
   rescue Cli::CommandFailedError
     false
   end


### PR DESCRIPTION
## Summary
- `kubectl get <resource> <name> -A` doesn't work — kubectl can't get a named resource across all namespaces
- This caused `installed?` to always return `false`, leading to re-install attempts that fail with Helm ownership conflicts
- Fixed by listing all resources of that type with `-A --no-headers` and checking if any line contains the expected name

## Test plan
- [ ] Deploy to cluster and verify traefik/cert-manager are detected as already installed
- [ ] Verify manual install click shows "already installed" message instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)