### PR TITLE
allow editing build cloud config when failed or uninstalled

### DIFF
--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -184,6 +184,7 @@ class K8::BuildCloudManager
   def wait_for_builder_ready!
     max_attempts = 120
     attempts = 0
+    logged_warnings = Set.new
 
     while attempts < max_attempts
       if builder_ready?
@@ -191,10 +192,16 @@ class K8::BuildCloudManager
         return true
       end
 
+      # Periodically check for pod scheduling issues
+      if (attempts % 6).zero? # every 30 seconds
+        check_pod_warnings(logged_warnings)
+      end
+
       sleep 5
       attempts += 1
     end
 
+    check_pod_warnings(logged_warnings)
     raise "BuildKit builder did not become ready in time"
   end
 
@@ -224,6 +231,26 @@ class K8::BuildCloudManager
     runner.call(%w[docker buildx rm] + [ build_cloud.name ])
   rescue StandardError => e
     Rails.logger.warn("Error removing builder: #{e.message}")
+  end
+
+  def check_pod_warnings(logged_warnings)
+    kubectl = Cli::RunAndReturnOutput.new
+    K8::Kubeconfig.with_kube_config(connection.kubeconfig, skip_tls_verify: connection.cluster.skip_tls_verify) do |kubeconfig_file|
+      output = kubectl.call(
+        %w[kubectl get events --field-selector type=Warning -o json] + [ "-n", namespace ],
+        envs: { "KUBECONFIG" => kubeconfig_file.path }
+      )
+      events = JSON.parse(output)
+      (events["items"] || []).each do |event|
+        message = "#{event.dig("reason")}: #{event.dig("message")}"
+        unless logged_warnings.include?(message)
+          logged_warnings.add(message)
+          build_cloud.warn(message)
+        end
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.debug("Failed to check pod warnings: #{e.message}")
   end
 
   def runner

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -2,6 +2,9 @@ class K8::BuildCloudManager
   include StorageHelper
   # Only referenced in the migration for now.
   BUILDKIT_BUILDER_DEFAULT_NAMESPACE = 'canine-k8s-builder'
+  READY_MAX_ATTEMPTS = 120
+  READY_POLL_INTERVAL = 5 # seconds
+  WARNING_CHECK_INTERVAL = 6 # check every 6 attempts (30 seconds)
 
   attr_reader :connection, :build_cloud
 
@@ -182,22 +185,21 @@ class K8::BuildCloudManager
   end
 
   def wait_for_builder_ready!
-    max_attempts = 120
     attempts = 0
     logged_warnings = Set.new
 
-    while attempts < max_attempts
+    while attempts < READY_MAX_ATTEMPTS
       if builder_ready?
         build_cloud.success("Builder is ready!")
         return true
       end
 
       # Periodically check for pod scheduling issues
-      if (attempts % 6).zero? # every 30 seconds
+      if (attempts % WARNING_CHECK_INTERVAL).zero?
         check_pod_warnings(logged_warnings)
       end
 
-      sleep 5
+      sleep READY_POLL_INTERVAL
       attempts += 1
     end
 

--- a/app/views/clusters/build_clouds/_show.html.erb
+++ b/app/views/clusters/build_clouds/_show.html.erb
@@ -106,8 +106,14 @@
                 Removing...
               </button>
             <% elsif build_cloud.uninstalled? || build_cloud.failed? %>
-              <%= button_to cluster_build_cloud_path(cluster), 
-                            method: :post, 
+              <%= link_to edit_cluster_build_cloud_path(cluster),
+                          class: "btn btn-outline btn-sm",
+                          data: { turbo_frame: dom_id(cluster, "build_cloud") } do %>
+                <iconify-icon icon="lucide:settings" height="16"></iconify-icon>
+                Edit
+              <% end %>
+              <%= button_to cluster_build_cloud_path(cluster),
+                            method: :post,
                             class: "btn btn-primary btn-sm",
                             data: { turbo_confirm: "Reinstall BuildKit on your cluster?" } do %>
                 <iconify-icon icon="lucide:refresh-cw" height="16"></iconify-icon>


### PR DESCRIPTION
## Summary
- Add Edit button alongside Reinstall when build cloud is in failed or uninstalled state
- Users can now adjust replicas, CPU, and memory settings before reinstalling (e.g., reducing replicas from 2 to 1 on resource-constrained clusters)

## Test plan
- [ ] Trigger a build cloud installation failure (e.g., insufficient resources)
- [ ] Verify Edit button appears next to Reinstall on the failed state
- [ ] Edit configuration (reduce replicas) and reinstall successfully