### PR TITLE
fix reinstall not working when build cloud is in failed state

### DIFF
--- a/app/controllers/clusters/build_clouds_controller.rb
+++ b/app/controllers/clusters/build_clouds_controller.rb
@@ -40,7 +40,7 @@ class Clusters::BuildCloudsController < Clusters::BaseController
   end
 
   def create
-    if @cluster.build_cloud.present? && !@cluster.build_cloud.uninstalled?
+    if @cluster.build_cloud.present? && !@cluster.build_cloud.uninstalled? && !@cluster.build_cloud.failed?
       redirect_to edit_cluster_path(@cluster), alert: "Build cloud is already installed on this cluster"
       return
     end


### PR DESCRIPTION
## Summary
- The `create` action guard blocked reinstall when build cloud status was `failed` — it only checked for `uninstalled`
- This was the reason clicking Reinstall appeared to do nothing

## Test plan
- [ ] Trigger a build cloud failure, then click Reinstall — should now start installation