### PR TITLE
fix build cloud destroy job and stale resource cleanup

### DIFF
--- a/app/controllers/clusters/build_clouds_controller.rb
+++ b/app/controllers/clusters/build_clouds_controller.rb
@@ -69,7 +69,7 @@ class Clusters::BuildCloudsController < Clusters::BaseController
       return
     end
 
-    Clusters::DestroyBuildCloudJob.perform_later(@cluster)
+    Clusters::DestroyBuildCloudJob.perform_later(@cluster, current_user)
     redirect_to edit_cluster_path(@cluster), notice: "Build cloud removal started. This may take a few minutes..."
   end
 

--- a/app/jobs/clusters/destroy_build_cloud_job.rb
+++ b/app/jobs/clusters/destroy_build_cloud_job.rb
@@ -2,19 +2,21 @@ module Clusters
   class DestroyBuildCloudJob < ApplicationJob
     queue_as :default
 
-    def perform(cluster)
+    def perform(cluster, user)
       Rails.logger.info("Starting build cloud removal for cluster #{cluster.name}")
 
       build_cloud = cluster.build_cloud
-      build_cloud.update(error_message: nil)
       return unless build_cloud
+
+      build_cloud.update(error_message: nil)
 
       begin
         # Update status to indicate removal is in progress
         build_cloud.update!(status: :uninstalling)
 
         # Initialize the build cloud manager
-        build_cloud_manager = K8::BuildCloudManager.new(cluster, build_cloud)
+        connection = K8::Connection.new(cluster, user)
+        build_cloud_manager = K8::BuildCloudManager.new(connection, build_cloud)
 
         # Teardown the builder
         build_cloud_manager.remove_builder!

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -171,10 +171,8 @@ class K8::BuildCloudManager
 
     build_cloud.info("Creating namespace #{namespace}...")
     ensure_namespace!
-    # Write kubeconfig to temp file for docker buildx
 
-    # Create the buildx builder with kubernetes driver
-    # The --bootstrap flag will start the builder immediately
+    # Create the buildx builder with kubernetes driver and bootstrap it
     K8::Kubeconfig.with_kube_config(connection.kubeconfig, skip_tls_verify: connection.cluster.skip_tls_verify) do |kubeconfig_file|
       build_cloud.info("Creating BuildKit builder with #{build_cloud.replicas} replicas...")
       command = %w[docker buildx create]
@@ -188,6 +186,16 @@ class K8::BuildCloudManager
       command += [ "--driver-opt", "limits.memory=#{integer_to_memory(build_cloud.memory_limits)}" ]
 
       runner.call(command, envs: { "KUBECONFIG" => kubeconfig_file.path })
+
+      # Bootstrap the builder to create the pods (don't wait for it to finish — we poll ourselves)
+      build_cloud.info("Bootstrapping builder pods...")
+      Cli::RunAndReturnOutput.new.call(
+        %w[docker buildx inspect --bootstrap] + [ build_cloud.name ],
+        envs: { "KUBECONFIG" => kubeconfig_file.path }
+      )
+    rescue Cli::CommandFailedError => e
+      # Bootstrap may fail with a timeout, but pods could still be starting
+      build_cloud.warn("Bootstrap returned an error (pods may still be starting): #{e.message}")
     end
 
     # Wait for builder to be ready

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -124,10 +124,11 @@ class K8::BuildCloudManager
     if builder_ready?
       build_cloud.info("Existing builder found, removing...")
       remove_builder!
-      create_builder!
     else
-      create_builder!
+      # Clean up any stale resources in the namespace even if builder isn't registered locally
+      cleanup_stale_resources!
     end
+    create_builder!
   end
 
   def create_local_builder!
@@ -224,6 +225,13 @@ class K8::BuildCloudManager
   rescue StandardError => e
     # Namespace might already exist, which is fine
     build_cloud.info("Namespace #{namespace} might already exist: #{e.message}")
+  end
+
+  def cleanup_stale_resources!
+    build_cloud.info("Cleaning up stale resources in namespace #{namespace}...")
+    K8::Kubectl.new(connection).call(%w[delete all --all --ignore-not-found=true] + [ "-n", namespace ])
+  rescue StandardError => e
+    build_cloud.warn("Failed to clean up stale resources: #{e.message}")
   end
 
   def remove_builder!

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -24,6 +24,9 @@ class K8::BuildCloudManager
 
     begin
       build_cloud.info("Starting build cloud installation on cluster #{build_cloud.cluster.name}")
+      build_cloud.info("Builder name: #{build_cloud.name}")
+      build_cloud.info("Namespace: #{build_cloud.namespace}")
+      build_cloud.info("Configuration: #{build_cloud.replicas} replicas, CPU #{integer_to_compute(build_cloud.cpu_requests)}/#{integer_to_compute(build_cloud.cpu_limits)}, Memory #{integer_to_memory(build_cloud.memory_requests)}/#{integer_to_memory(build_cloud.memory_limits)}")
 
       # Initialize the K8::BuildCloud service with the build_cloud model
       build_cloud_manager = K8::BuildCloudManager.new(
@@ -38,11 +41,12 @@ class K8::BuildCloudManager
 
       # Check if builder is ready
       if build_cloud_manager.builder_ready?
+        version = build_cloud_manager.get_buildkit_version
         # Update build cloud record with success
         build_cloud.update!(
           status: :active,
           installed_at: Time.current,
-          driver_version: build_cloud_manager.get_buildkit_version,
+          driver_version: version,
           installation_metadata: build_cloud.installation_metadata.merge(
             completed_at: Time.current,
             builder_ready: true
@@ -50,6 +54,7 @@ class K8::BuildCloudManager
         )
 
         build_cloud.success("Build cloud installed successfully!")
+        build_cloud.info("BuildKit version: #{version}")
       else
         raise "Builder was created but is not ready"
       end
@@ -196,12 +201,13 @@ class K8::BuildCloudManager
 
     while attempts < READY_MAX_ATTEMPTS
       if builder_ready?
-        build_cloud.success("Builder is ready!")
+        build_cloud.success("Builder is ready! All pods are running.")
         return true
       end
 
-      # Periodically check for pod scheduling issues
+      # Periodically log pod status and check for warnings
       if (attempts % WARNING_CHECK_INTERVAL).zero?
+        log_pod_status
         check_pod_warnings(logged_warnings)
       end
 
@@ -209,8 +215,9 @@ class K8::BuildCloudManager
       attempts += 1
     end
 
+    log_pod_status
     check_pod_warnings(logged_warnings)
-    raise "BuildKit builder did not become ready in time"
+    raise "BuildKit builder did not become ready in time (waited #{READY_MAX_ATTEMPTS * READY_POLL_INTERVAL / 60} minutes)"
   end
 
   def ensure_builder_active!
@@ -224,12 +231,14 @@ class K8::BuildCloudManager
 
   def ensure_namespace!
     # Create namespace if it doesn't exist
+    quiet_runner = Cli::RunAndReturnOutput.new
     K8::Kubeconfig.with_kube_config(connection.kubeconfig, skip_tls_verify: connection.cluster.skip_tls_verify) do |kubeconfig_file|
-      runner.call(%w[kubectl create namespace] + [ namespace ], envs: { "KUBECONFIG" => kubeconfig_file.path })
+      quiet_runner.call(%w[kubectl create namespace] + [ namespace ], envs: { "KUBECONFIG" => kubeconfig_file.path })
     end
+    build_cloud.success("Namespace #{namespace} created")
   rescue StandardError => e
     # Namespace might already exist, which is fine
-    build_cloud.info("Namespace #{namespace} might already exist: #{e.message}")
+    build_cloud.info("Namespace #{namespace} already exists")
   end
 
   def cleanup_stale_resources!
@@ -246,6 +255,30 @@ class K8::BuildCloudManager
     runner.call(%w[docker buildx rm] + [ build_cloud.name ])
   rescue StandardError => e
     Rails.logger.warn("Error removing builder: #{e.message}")
+  end
+
+  def log_pod_status
+    quiet_runner = Cli::RunAndReturnOutput.new
+    K8::Kubeconfig.with_kube_config(connection.kubeconfig, skip_tls_verify: connection.cluster.skip_tls_verify) do |kubeconfig_file|
+      output = quiet_runner.call(
+        %w[kubectl get pods -o json] + [ "-n", namespace ],
+        envs: { "KUBECONFIG" => kubeconfig_file.path }
+      )
+      pods = JSON.parse(output)
+      (pods["items"] || []).each do |pod|
+        name = pod.dig("metadata", "name")
+        phase = pod.dig("status", "phase")
+        ready = pod.dig("status", "containerStatuses")&.all? { |c| c["ready"] }
+        status_text = ready ? "Ready" : phase
+        build_cloud.info("Pod #{name}: #{status_text}")
+      end
+
+      total = (pods["items"] || []).size
+      ready_count = (pods["items"] || []).count { |p| p.dig("status", "containerStatuses")&.all? { |c| c["ready"] } }
+      build_cloud.info("Pods ready: #{ready_count}/#{total} (need #{build_cloud.replicas})")
+    end
+  rescue StandardError => e
+    Rails.logger.debug("Failed to check pod status: #{e.message}")
   end
 
   def check_pod_warnings(logged_warnings)

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -103,8 +103,13 @@ class K8::BuildCloudManager
   def builder_ready?
     quiet_runner = Cli::RunAndReturnOutput.new
     output = quiet_runner.call(%w[docker buildx ls --format json])
-    builder_names = output.split("\n").map { |x| JSON.parse(x) }.map { |x| x["Name"] }
-    builder_names.include?(build_cloud.name)
+    builders = output.split("\n").map { |x| JSON.parse(x) }
+    builder = builders.find { |x| x["Name"] == build_cloud.name }
+    return false unless builder
+
+    # Verify at least one node is running, not just registered
+    nodes = builder["Nodes"] || []
+    nodes.any? { |n| n["Status"] == "running" }
   rescue StandardError
     false
   end


### PR DESCRIPTION
## Summary
- **DestroyBuildCloudJob** was passing `cluster` directly to `BuildCloudManager.new` instead of a `K8::Connection` — this meant Remove always crashed
- Fix nil check ordering in destroy job (called `build_cloud.update` before `return unless build_cloud`)
- Pass `current_user` to destroy job so it can create a proper `K8::Connection`
- Add `cleanup_stale_resources!` to delete old pods/deployments in the builder namespace before reinstall, preventing stale resources from blocking new builder creation

## Test plan
- [ ] Remove an active build cloud — should succeed without errors
- [ ] Reinstall a failed build cloud — should clean up old pods first
- [ ] Verify logs show cleanup messages during reinstall