### PR TITLE
add APP_HOST env var to helm deployments

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,10 +56,8 @@ spec:
               value: "{{ .Values.canine.allowedHostname }}"
             - name: ONBOARDING_METHOD
               value: "{{ .Values.canine.onboardingMethod }}"
-            {{- if .Values.ingress.enabled }}
             - name: APP_HOST
-              value: "{{ (index .Values.ingress.hosts 0).host }}"
-            {{- end }}
+              value: "{{ .Values.canine.appHost | default (ternary (index .Values.ingress.hosts 0).host "localhost" .Values.ingress.enabled) }}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
               value: "{{ .Values.canine.allowedHostname }}"
             - name: ONBOARDING_METHOD
               value: "{{ .Values.canine.onboardingMethod }}"
+            {{- if .Values.ingress.enabled }}
+            - name: APP_HOST
+              value: "{{ (index .Values.ingress.hosts 0).host }}"
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -52,10 +52,8 @@ spec:
               value: "{{ .Values.canine.allowedHostname }}"
             - name: ONBOARDING_METHOD
               value: "{{ .Values.canine.onboardingMethod }}"
-            {{- if .Values.ingress.enabled }}
             - name: APP_HOST
-              value: "{{ (index .Values.ingress.hosts 0).host }}"
-            {{- end }}
+              value: "{{ .Values.canine.appHost | default (ternary (index .Values.ingress.hosts 0).host "localhost" .Values.ingress.enabled) }}"
             - name: GOOD_JOB_MAX_THREADS
               value: "{{ .Values.worker.maxThreads | default 5 }}"
             - name: GOOD_JOB_QUEUES

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -52,6 +52,10 @@ spec:
               value: "{{ .Values.canine.allowedHostname }}"
             - name: ONBOARDING_METHOD
               value: "{{ .Values.canine.onboardingMethod }}"
+            {{- if .Values.ingress.enabled }}
+            - name: APP_HOST
+              value: "{{ (index .Values.ingress.hosts 0).host }}"
+            {{- end }}
             - name: GOOD_JOB_MAX_THREADS
               value: "{{ .Values.worker.maxThreads | default 5 }}"
             - name: GOOD_JOB_QUEUES

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,9 @@ canine:
   # Use comma-separated list for specific hosts: "example.com,api.example.com"
   # Leave empty to only allow localhost (default)
   allowedHostname: "*"
+  # Application hostname used for generating URLs in background jobs
+  # Defaults to the first ingress host if ingress is enabled
+  appHost: ""
   # Email for Let's Encrypt certificate registration
   acmeEmail: "admin@example.com"
 


### PR DESCRIPTION
## Summary
- Add `APP_HOST` env var to both web and worker deployment templates, derived from the first ingress host
- Without this, Turbo broadcasts that generate URLs crash with `ArgumentError: Missing host to link to!` because `default_url_options[:host]` is nil
- Only set when ingress is enabled (since that's when we have a known hostname)

## Test plan
- [ ] `helm upgrade` and verify `APP_HOST` is set in pods
- [ ] Trigger a deploy — should no longer 500