### PR TITLE
default to build cloud in cluster mode and fix demo reset duplication

### DIFF
--- a/app/jobs/scheduled/reset_demo_projects_job.rb
+++ b/app/jobs/scheduled/reset_demo_projects_job.rb
@@ -18,10 +18,10 @@ module Scheduled
     private
 
     def demo_reset_due?(project)
-      last_deployed = project.last_deployment_at
-      return true if last_deployed.nil?
+      last_build_at = project.builds.maximum(:created_at)
+      return true if last_build_at.nil?
 
-      last_deployed + DEMO_RESET_INTERVAL <= Time.current
+      last_build_at + DEMO_RESET_INTERVAL <= Time.current
     end
   end
 end

--- a/app/models/build_configuration.rb
+++ b/app/models/build_configuration.rb
@@ -28,7 +28,13 @@
 #  fk_rails_...  (provider_id => providers.id)
 #
 class BuildConfiguration < ApplicationRecord
-  DEFAULT_BUILDER = Rails.application.config.cloud_mode ? :cloud : :docker
+  DEFAULT_BUILDER = if Rails.application.config.cloud_mode
+    :cloud
+  elsif Rails.application.config.cluster_mode
+    :k8s
+  else
+    :docker
+  end
   BUILDER_OPTIONS = if Rails.application.config.local_mode
     [ :docker, :k8s ]
   elsif Rails.application.config.cloud_mode

--- a/app/views/projects/build_configurations/_form.html.erb
+++ b/app/views/projects/build_configurations/_form.html.erb
@@ -65,7 +65,7 @@
         <label class="label mb-2">
           <span class="label-text">Build driver</span>
         </label>
-        <%= render "shared/partials/radio_selector", selected: build_configuration.driver || (Rails.application.config.local_mode ? "docker" : "cloud"), options: [
+        <%= render "shared/partials/radio_selector", selected: build_configuration.driver || BuildConfiguration::DEFAULT_BUILDER.to_s, options: [
           {
             icon: "skill-icons:docker",
             name: "project[build_configuration][driver]",

--- a/app/views/projects/build_configurations/_k8s_build_cloud.html.erb
+++ b/app/views/projects/build_configurations/_k8s_build_cloud.html.erb
@@ -19,7 +19,15 @@
   <% else %>
     <div class="alert alert-warning">
       <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-      <span>No clusters are configured for container builds. Please enable container builds on at least one cluster in the cluster settings.</span>
+      <span>
+        No clusters are configured for container builds.
+        <% cluster = current_account.clusters.first %>
+        <% if cluster %>
+          <%= link_to "Configure Build Cloud", cluster_build_cloud_path(cluster), class: "link link-primary" %>
+        <% else %>
+          Please enable container builds on at least one cluster in the cluster settings.
+        <% end %>
+      </span>
     </div>
     <%= bc_form.hidden_field :cluster_id, value: nil %>
   <% end %>


### PR DESCRIPTION
## Summary
- Default the build driver to **Build Cloud (k8s)** when running in cluster mode, since it's the only available option
- Show a "Configure Build Cloud" link on the build config form when no build cloud is set up, pointing to the cluster's build cloud settings
- Use `BuildConfiguration::DEFAULT_BUILDER` constant in the form instead of duplicating the mode logic
- Fix demo project reset job checking `last_deployment_at` instead of last build time, which could cause duplicate builds to queue on every 5-minute poll

## Test plan
- [ ] Set `BOOT_MODE=cluster` and verify the build driver defaults to K8s Build Cloud
- [ ] Verify the "Configure Build Cloud" link appears when no build cloud is configured
- [ ] Verify demo project reset doesn't trigger duplicate builds within the 24h window

🤖 Generated with [Claude Code](https://claude.com/claude-code)