### PR TITLE
Add build cloud refresh and fix stale builder reinstall

### DIFF
--- a/app/controllers/clusters/build_clouds_controller.rb
+++ b/app/controllers/clusters/build_clouds_controller.rb
@@ -56,6 +56,31 @@ class Clusters::BuildCloudsController < Clusters::BaseController
     redirect_to edit_cluster_path(@cluster), notice: "Build cloud installation started. This may take a few minutes..."
   end
 
+  def refresh
+    @build_cloud = @cluster.build_cloud
+
+    if @build_cloud.blank?
+      redirect_to edit_cluster_path(@cluster), alert: "No build cloud found for this cluster"
+      return
+    end
+
+    connection = K8::Connection.new(@cluster, current_user)
+    manager = K8::BuildCloudManager.new(connection, @build_cloud)
+
+    if manager.builder_ready?
+      @build_cloud.update!(status: :active, error_message: nil) unless @build_cloud.active?
+    elsif manager.ensure_active!
+      @build_cloud.update!(status: :active, error_message: nil) unless @build_cloud.active?
+    else
+      @build_cloud.update!(status: :failed, error_message: "Builder pods are not running") unless @build_cloud.installing?
+    end
+
+    render partial: "clusters/build_clouds/show", locals: { cluster: @cluster }
+  rescue StandardError => e
+    @build_cloud.update!(status: :failed, error_message: e.message) unless @build_cloud.installing?
+    render partial: "clusters/build_clouds/show", locals: { cluster: @cluster }
+  end
+
   def destroy
     @build_cloud = @cluster.build_cloud
 

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -131,12 +131,7 @@ class K8::BuildCloudManager
   end
 
   def create_or_update_builder!
-    if builder_ready?
-      build_cloud.info("Existing builder found, removing...")
-      remove_builder!
-    else
-      cleanup_stale_resources!
-    end
+    cleanup_stale_resources!
     create_builder!
   end
 

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -82,9 +82,11 @@ class K8::BuildCloudManager
     @build_cloud = build_cloud
   end
 
-  def ensure_active!
-    # TODO: Check the pods in the namespace and ensure they are running.
-    K8::Client.new(connection).pods_for_namespace(build_cloud.namespace).any?
+  def remote_builder_active?
+    pods = K8::Client.new(connection).pods_for_namespace(build_cloud.namespace)
+    return false if pods.empty?
+
+    pods.all? { |pod| pod.status.phase == "Running" }
   end
 
   def get_buildkit_version
@@ -136,7 +138,7 @@ class K8::BuildCloudManager
   end
 
   def create_local_builder!
-    if ensure_active!
+    if remote_builder_active?
       create_builder!
     else
       raise "Remote builder is not active, please enable the build cloud first."
@@ -144,7 +146,7 @@ class K8::BuildCloudManager
   end
 
   def remove_local_builder!
-    if ensure_active!
+    if remote_builder_active?
       local_runner = Cli::RunAndReturnOutput.new
       local_runner.call(%w[docker buildx rm --keep-daemon] + [ build_cloud.name ])
     else

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -135,10 +135,7 @@ class K8::BuildCloudManager
       build_cloud.info("Existing builder found, removing...")
       remove_builder!
     else
-      # Clean up any stale resources in the namespace even if builder isn't registered locally
       cleanup_stale_resources!
-      # Remove stale local builder registration (inactive, temp kubeconfig gone, etc.)
-      remove_local_stale_builder! if local_builder_exists?
     end
     create_builder!
   end
@@ -254,16 +251,13 @@ class K8::BuildCloudManager
   def cleanup_stale_resources!
     build_cloud.info("Cleaning up stale resources in namespace #{namespace}...")
     K8::Kubectl.new(connection).call(%w[delete all --all --ignore-not-found=true] + [ "-n", namespace ])
+
+    if local_builder_exists?
+      build_cloud.info("Removing stale local builder registration...")
+      Cli::RunAndReturnOutput.new.call(%w[docker buildx rm] + [ build_cloud.name ])
+    end
   rescue StandardError => e
     build_cloud.warn("Failed to clean up stale resources: #{e.message}")
-  end
-
-  def remove_local_stale_builder!
-    build_cloud.info("Removing stale local builder registration...")
-    local_runner = Cli::RunAndReturnOutput.new
-    local_runner.call(%w[docker buildx rm] + [ build_cloud.name ])
-  rescue StandardError => e
-    build_cloud.warn("Failed to remove stale builder: #{e.message}")
   end
 
   def remove_builder!

--- a/app/services/k8/build_cloud_manager.rb
+++ b/app/services/k8/build_cloud_manager.rb
@@ -137,6 +137,8 @@ class K8::BuildCloudManager
     else
       # Clean up any stale resources in the namespace even if builder isn't registered locally
       cleanup_stale_resources!
+      # Remove stale local builder registration (inactive, temp kubeconfig gone, etc.)
+      remove_local_stale_builder! if local_builder_exists?
     end
     create_builder!
   end
@@ -254,6 +256,14 @@ class K8::BuildCloudManager
     K8::Kubectl.new(connection).call(%w[delete all --all --ignore-not-found=true] + [ "-n", namespace ])
   rescue StandardError => e
     build_cloud.warn("Failed to clean up stale resources: #{e.message}")
+  end
+
+  def remove_local_stale_builder!
+    build_cloud.info("Removing stale local builder registration...")
+    local_runner = Cli::RunAndReturnOutput.new
+    local_runner.call(%w[docker buildx rm] + [ build_cloud.name ])
+  rescue StandardError => e
+    build_cloud.warn("Failed to remove stale builder: #{e.message}")
   end
 
   def remove_builder!

--- a/app/views/clusters/build_clouds/_show.html.erb
+++ b/app/views/clusters/build_clouds/_show.html.erb
@@ -8,7 +8,15 @@
           <iconify-icon icon="lucide:cloud" height="24" class="text-primary"></iconify-icon>
           <h3 class="card-title text-lg">Build Cloud</h3>
         </div>
-        <%= render "clusters/build_clouds/status", build_cloud: %>
+        <div class="flex items-center gap-2">
+          <%= button_to refresh_cluster_build_cloud_path(cluster),
+                        method: :post,
+                        class: "btn btn-ghost btn-xs",
+                        data: { turbo_frame: dom_id(cluster, "build_cloud") } do %>
+            <iconify-icon icon="lucide:refresh-cw" height="14"></iconify-icon>
+          <% end %>
+          <%= render "clusters/build_clouds/status", build_cloud: %>
+        </div>
       </div>
 
       <% if build_cloud.installing? %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module Canine
     config.autoload_lib(ignore: %w[assets tasks])
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]
     config.after_initialize do |app|
-      Rails.application.routes.default_url_options[:host] = ENV["APP_HOST"]
+      Rails.application.routes.default_url_options[:host] = ENV["APP_HOST"] if ENV["APP_HOST"].present?
     end
     config.hosts << ENV['APP_HOST']
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,9 @@ Rails.application.routes.draw do
       get :logs
     end
     resource :metrics, only: [ :show ], module: :clusters
-    resource :build_cloud, only: [ :show, :edit, :update, :create, :destroy ], module: :clusters
+    resource :build_cloud, only: [ :show, :edit, :update, :create, :destroy ], module: :clusters do
+      post :refresh, on: :member
+    end
     resources :cluster_packages, only: [ :create, :destroy ], module: :clusters do
       collection do
         post :sync


### PR DESCRIPTION
## Summary
- Add refresh button to build cloud panel that checks real BuildKit pod status on the cluster
- Fix reinstall failing when a stale local builder registration exists (inactive builder with expired temp kubeconfig)
- Only set `default_url_options[:host]` when `APP_HOST` env var is present

## Test plan
- [ ] Test build cloud refresh button updates status from cluster state
- [ ] Test build cloud reinstall after a previous failed/stale install
- [ ] Verify no `Missing host to link to` errors when `APP_HOST` is unset