### PR TITLE
fix kubectl commands passed as single string instead of array

### DIFF
--- a/app/services/k8/client.rb
+++ b/app/services/k8/client.rb
@@ -23,14 +23,14 @@ module K8
     end
 
     def get_raw_secret_value(secret_name, namespace, key)
-      result = K8::Kubectl.new(@_kubeconfig).call("get secret #{secret_name} -n #{namespace} -o json")
+      result = K8::Kubectl.new(@_kubeconfig).call(%w[get secret] + [secret_name, "-n", namespace, "-o", "json"])
       data = JSON.parse(result, object_class: OpenStruct).data
       Base64.decode64(data.to_h[key.to_sym])
       # Base64.decode64(JSON.parse(r)['auths']['registry.gitlab.com']['auth'])
     end
 
     def get_ingresses(namespace:)
-      result = K8::Kubectl.new(@connection).call("get ingresses -n #{namespace} -o json")
+      result = K8::Kubectl.new(@connection).call(%w[get ingresses -n] + [namespace, "-o", "json"])
       JSON.parse(result, object_class: OpenStruct).items
     end
 

--- a/app/services/k8/client.rb
+++ b/app/services/k8/client.rb
@@ -23,14 +23,14 @@ module K8
     end
 
     def get_raw_secret_value(secret_name, namespace, key)
-      result = K8::Kubectl.new(@_kubeconfig).call(%w[get secret] + [secret_name, "-n", namespace, "-o", "json"])
+      result = K8::Kubectl.new(@_kubeconfig).call(%w[get secret] + [ secret_name, "-n", namespace, "-o", "json" ])
       data = JSON.parse(result, object_class: OpenStruct).data
       Base64.decode64(data.to_h[key.to_sym])
       # Base64.decode64(JSON.parse(r)['auths']['registry.gitlab.com']['auth'])
     end
 
     def get_ingresses(namespace:)
-      result = K8::Kubectl.new(@connection).call(%w[get ingresses -n] + [namespace, "-o", "json"])
+      result = K8::Kubectl.new(@connection).call(%w[get ingresses -n] + [ namespace, "-o", "json" ])
       JSON.parse(result, object_class: OpenStruct).items
     end
 


### PR DESCRIPTION
## Summary
- Fix `get_ingresses` and `get_raw_secret_value` in `K8::Client` where kubectl commands were passed as a single string instead of an array of arguments
- `Array("get ingresses -n ns -o json")` wraps the whole string as one element, so `Open3.capture3` passes it as a single argument to kubectl, causing `unknown command` errors

## Test plan
- [ ] Verify add-ons edit page loads without error
- [ ] Verify secret retrieval still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)