### PR TITLE
Add Helm install as default tab on landing pages

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -2,6 +2,8 @@ class StaticController < ApplicationController
   INSTALL_SCRIPT = "curl -sSL https://canine.sh/install.sh | bash"
   MAC_INSTALL_SCRIPT = "brew tap CanineHQ/canine && brew install canine"
   MAC_START_SCRIPT = "canine local start"
+  HELM_REPO_SCRIPT = "helm repo add canine https://caninehq.github.io/canine && helm repo update"
+  HELM_INSTALL_SCRIPT = "helm install canine canine/canine \\\n  --namespace canine \\\n  --create-namespace \\\n  --set ingress.enabled=true \\\n  --set ingress.hostname=canine.example.com \\\n  --set canine.acmeEmail=you@example.com"
   skip_before_action :authenticate_user!
   ILLUSTRATIONS = [
     {

--- a/app/views/static/landing_page/_open_source.html.erb
+++ b/app/views/static/landing_page/_open_source.html.erb
@@ -14,22 +14,31 @@
           <span class="w-3 h-3 rounded-full bg-yellow-500"></span>
           <span class="w-3 h-3 rounded-full bg-green-500"></span>
           <div role="tablist" class="tabs tabs-bordered ml-4">
-            <a role="tab" class="tab tab-active text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="mac">macOS</a>
+            <a role="tab" class="tab tab-active text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="helm">Helm</a>
+            <a role="tab" class="tab text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="mac">macOS</a>
             <a role="tab" class="tab text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="linux">Linux</a>
           </div>
         </div>
 
-        <div data-tabs-target="panel" data-tab="linux" class="hidden cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::INSTALL_SCRIPT %>">
-          <pre class="bg-gray-800 text-gray-100 text-sm font-mono px-4 py-2 overflow-x-auto"><code><span class="text-gray-400"># Install & run with Docker</span>
-<span class="text-green-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::INSTALL_SCRIPT %></span></code></pre>
+        <div data-tabs-target="panel" data-tab="helm" class="cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::HELM_REPO_SCRIPT %> && <%= StaticController::HELM_INSTALL_SCRIPT %>">
+          <pre class="bg-gray-800 text-gray-100 text-sm font-mono px-4 py-2 overflow-x-auto"><code><span class="text-gray-400"># Add the Helm repo</span>
+<span class="text-green-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::HELM_REPO_SCRIPT %></span>
+
+<span class="text-gray-400"># Install on your Kubernetes cluster</span>
+<span class="text-green-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::HELM_INSTALL_SCRIPT %></span></code></pre>
         </div>
 
-        <div data-tabs-target="panel" data-tab="mac" class="cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::MAC_INSTALL_SCRIPT %> && <%= StaticController::MAC_START_SCRIPT %>">
+        <div data-tabs-target="panel" data-tab="mac" class="hidden cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::MAC_INSTALL_SCRIPT %> && <%= StaticController::MAC_START_SCRIPT %>">
           <pre class="bg-gray-800 text-gray-100 text-sm font-mono px-4 py-2 overflow-x-auto"><code><span class="text-gray-400"># Install via Homebrew</span>
 <span class="text-green-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::MAC_INSTALL_SCRIPT %></span>
 
 <span class="text-gray-400"># Start Canine locally</span>
 <span class="text-green-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::MAC_START_SCRIPT %></span></code></pre>
+        </div>
+
+        <div data-tabs-target="panel" data-tab="linux" class="hidden cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::INSTALL_SCRIPT %>">
+          <pre class="bg-gray-800 text-gray-100 text-sm font-mono px-4 py-2 overflow-x-auto"><code><span class="text-gray-400"># Install & run with Docker</span>
+<span class="text-green-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::INSTALL_SCRIPT %></span></code></pre>
         </div>
       </div>
       <div class="mt-2 text-sm text-gray-400 text-center">

--- a/app/views/static/self_hosted.html.erb
+++ b/app/views/static/self_hosted.html.erb
@@ -84,12 +84,13 @@
             <span class="w-3 h-3 rounded-full bg-yellow-500"></span>
             <span class="w-3 h-3 rounded-full bg-green-500"></span>
             <div role="tablist" class="tabs tabs-bordered ml-4">
-              <a role="tab" class="tab tab-active text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="mac">macOS</a>
+              <a role="tab" class="tab tab-active text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="helm">Helm</a>
+              <a role="tab" class="tab text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="mac">macOS</a>
               <a role="tab" class="tab text-gray-300" data-action="click->tabs#select" data-tabs-target="tab" data-tab="linux">Linux</a>
             </div>
           </div>
 
-          <div data-tabs-target="panel" data-tab="mac" class="cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::MAC_INSTALL_SCRIPT %> && <%= StaticController::MAC_START_SCRIPT %>">
+          <div data-tabs-target="panel" data-tab="mac" class="hidden cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::MAC_INSTALL_SCRIPT %> && <%= StaticController::MAC_START_SCRIPT %>">
             <pre class="bg-gray-950 text-gray-100 text-sm font-mono px-6 py-4 overflow-x-auto"><code><span class="text-gray-400"># Install via Homebrew</span>
 <span class="text-emerald-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::MAC_INSTALL_SCRIPT %></span>
 
@@ -100,6 +101,14 @@
           <div data-tabs-target="panel" data-tab="linux" class="hidden cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::INSTALL_SCRIPT %>">
             <pre class="bg-gray-950 text-gray-100 text-sm font-mono px-6 py-4 overflow-x-auto"><code><span class="text-gray-400"># Install & run with Docker</span>
 <span class="text-emerald-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::INSTALL_SCRIPT %></span></code></pre>
+          </div>
+
+          <div data-tabs-target="panel" data-tab="helm" class="cursor-pointer group" data-controller="clipboard" data-clipboard-text="<%= StaticController::HELM_REPO_SCRIPT %> && <%= StaticController::HELM_INSTALL_SCRIPT %>">
+            <pre class="bg-gray-950 text-gray-100 text-sm font-mono px-6 py-4 overflow-x-auto"><code><span class="text-gray-400"># Add the Helm repo</span>
+<span class="text-emerald-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::HELM_REPO_SCRIPT %></span>
+
+<span class="text-gray-400"># Install on your Kubernetes cluster</span>
+<span class="text-emerald-400">$</span> <span class="group-hover:text-blue-300 transition-all"><%= StaticController::HELM_INSTALL_SCRIPT %></span></code></pre>
           </div>
         </div>
         <p class="mt-3 text-sm text-gray-400 text-center">Click to copy. Run this on your laptop, not your cluster.</p>


### PR DESCRIPTION
## Summary
- Adds a Helm tab to the install command sections on both the main landing page and self-hosted page
- Makes Helm the default/primary install method, with macOS and Linux as secondary tabs
- Helm install command is displayed as a readable multi-line command

## Test plan
- [ ] Verify Helm tab is shown by default on `/` and `/self-hosted`
- [ ] Verify clicking macOS/Linux tabs still works
- [ ] Verify click-to-copy copies the full command