### PR TITLE
Add Active Record encryption keys for 2FA

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -58,6 +58,21 @@ spec:
               value: "{{ .Values.canine.onboardingMethod }}"
             - name: APP_HOST
               value: "{{ .Values.canine.appHost | default (ternary .Values.ingress.hostname "localhost" .Values.ingress.enabled) }}"
+            - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canine.fullname" . }}
+                  key: encryption-primary-key
+            - name: ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canine.fullname" . }}
+                  key: encryption-deterministic-key
+            - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canine.fullname" . }}
+                  key: encryption-key-derivation-salt
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -14,3 +14,12 @@ data:
   {{- else }}
   secret-key-base: {{ randAlphaNum 64 | b64enc | quote }}
   {{- end }}
+  {{- if and $existingSecret (hasKey $existingSecret.data "encryption-primary-key") }}
+  encryption-primary-key: {{ index $existingSecret.data "encryption-primary-key" }}
+  encryption-deterministic-key: {{ index $existingSecret.data "encryption-deterministic-key" }}
+  encryption-key-derivation-salt: {{ index $existingSecret.data "encryption-key-derivation-salt" }}
+  {{- else }}
+  encryption-primary-key: {{ randAlphaNum 32 | b64enc | quote }}
+  encryption-deterministic-key: {{ randAlphaNum 32 | b64enc | quote }}
+  encryption-key-derivation-salt: {{ randAlphaNum 32 | b64enc | quote }}
+  {{- end }}

--- a/templates/worker-deployment.yaml
+++ b/templates/worker-deployment.yaml
@@ -54,6 +54,21 @@ spec:
               value: "{{ .Values.canine.onboardingMethod }}"
             - name: APP_HOST
               value: "{{ .Values.canine.appHost | default (ternary .Values.ingress.hostname "localhost" .Values.ingress.enabled) }}"
+            - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canine.fullname" . }}
+                  key: encryption-primary-key
+            - name: ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canine.fullname" . }}
+                  key: encryption-deterministic-key
+            - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "canine.fullname" . }}
+                  key: encryption-key-derivation-salt
             - name: GOOD_JOB_MAX_THREADS
               value: "{{ .Values.worker.maxThreads | default 5 }}"
             - name: GOOD_JOB_QUEUES


### PR DESCRIPTION
## Summary
- Auto-generates Active Record encryption keys (primary, deterministic, key derivation salt) in the Helm Secret
- Preserves existing keys on `helm upgrade` via `lookup`, same pattern as `secretKeyBase`
- Injects keys as env vars into both web and worker deployments
- Required for `devise-two-factor` v6 which uses Active Record encryption for OTP secrets

## Test plan
- [ ] Fresh `helm install` generates keys in the Secret
- [ ] `helm upgrade` preserves existing keys
- [ ] App boots without encryption credential errors