### PR TITLE
fix memory leaks in Stimulus controllers

### DIFF
--- a/app/javascript/controllers/buildpack_fields_controller.js
+++ b/app/javascript/controllers/buildpack_fields_controller.js
@@ -11,12 +11,12 @@ export default class extends Controller {
     this.selectedPacks = []
     this.initializeSortable()
 
-    // Listen for buildpack selection from search
-    this.element.addEventListener("buildpack-search:buildpack-selected", this.handleSearchSelection.bind(this))
+    this.boundHandleSearchSelection = this.handleSearchSelection.bind(this)
+    this.element.addEventListener("buildpack-search:buildpack-selected", this.boundHandleSearchSelection)
   }
 
   disconnect() {
-    this.element.removeEventListener("buildpack-search:buildpack-selected", this.handleSearchSelection.bind(this))
+    this.element.removeEventListener("buildpack-search:buildpack-selected", this.boundHandleSearchSelection)
   }
 
   handleSearchSelection(event) {

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
   connect() {
     const title = this.configValue.title
-    const chart = new ApexCharts(this.element, {
+    this.chart = new ApexCharts(this.element, {
       chart: {
         foreColor: '#fff',
         type: 'area',
@@ -98,7 +98,13 @@ export default class extends Controller {
         max: this.suggestedMaxY(),
       }
     })
-    chart.render();
+    this.chart.render();
+  }
+
+  disconnect() {
+    if (this.chart) {
+      this.chart.destroy();
+    }
   }
 
   value(point) {

--- a/app/javascript/controllers/git_select_repository_controller.js
+++ b/app/javascript/controllers/git_select_repository_controller.js
@@ -8,7 +8,8 @@ export default class extends Controller {
 
   connect() {
     this.page = 1
-    this.repositoriesListTarget.addEventListener("scroll", this.onScroll.bind(this))
+    this.boundOnScroll = this.onScroll.bind(this)
+    this.repositoriesListTarget.addEventListener("scroll", this.boundOnScroll)
     this.searchFunc = debounce(async (e) => {
       const searchTerm = e.target.value.toLowerCase()
       await get(`${this.endpointValue}?q=${searchTerm}&provider_id=${this.selectedProviderId}`, {
@@ -60,6 +61,10 @@ export default class extends Controller {
     this.buttonTarget.setAttribute("disabled", "true")
     this.page = 1
     this.fetchMoreRepositories();
+  }
+
+  disconnect() {
+    this.repositoriesListTarget.removeEventListener("scroll", this.boundOnScroll)
   }
 
   async onScroll(event) {

--- a/app/javascript/controllers/global_search_controller.js
+++ b/app/javascript/controllers/global_search_controller.js
@@ -6,11 +6,12 @@ export default class extends Controller {
 
   connect() {
     this.searchHandler = debounce(this.performSearch.bind(this), 300)
-    document.addEventListener('keydown', this.handleKeydown.bind(this))
+    this.boundHandleKeydown = this.handleKeydown.bind(this)
+    document.addEventListener('keydown', this.boundHandleKeydown)
   }
 
   disconnect() {
-    document.removeEventListener('keydown', this.handleKeydown.bind(this))
+    document.removeEventListener('keydown', this.boundHandleKeydown)
   }
 
   handleKeydown(e) {

--- a/app/javascript/controllers/logs_controller.js
+++ b/app/javascript/controllers/logs_controller.js
@@ -9,19 +9,18 @@ export default class extends Controller {
   }
 
   connect() {
-    // Scroll to the bottom of the container
     this.scrollToBottom();
 
-    // Add event listener for Turbo Frame load
-    document.addEventListener('turbo:frame-load', this.scrollToBottom.bind(this));
+    this.boundScrollToBottom = this.scrollToBottom.bind(this);
+    document.addEventListener('turbo:frame-load', this.boundScrollToBottom);
     this.interval = setInterval(() => {
-      // Fetch new logs
       this.loadNewLogs();
     }, REFRESH_INTERVAL);
   }
 
   disconnect() {
     clearInterval(this.interval);
+    document.removeEventListener('turbo:frame-load', this.boundScrollToBottom);
   }
 
   async loadNewLogs() {

--- a/app/javascript/controllers/progress_progressing_controller.js
+++ b/app/javascript/controllers/progress_progressing_controller.js
@@ -4,10 +4,14 @@ export default class extends Controller {
   connect() {
     const progress = this.element;
     let value = 0;
-    
-    setInterval(() => {
+
+    this.interval = setInterval(() => {
       value = (value + 1) % 101;
       progress.value = value;
     }, 15);
+  }
+
+  disconnect() {
+    clearInterval(this.interval);
   }
 }

--- a/app/javascript/controllers/rich_select_controller.js
+++ b/app/javascript/controllers/rich_select_controller.js
@@ -5,11 +5,13 @@ export default class extends Controller {
 
   connect() {
     this.closeOnOutsideClick = this.closeOnOutsideClick.bind(this)
-    this.inputTarget.addEventListener("invalid", this.onInvalid.bind(this))
+    this.boundOnInvalid = this.onInvalid.bind(this)
+    this.inputTarget.addEventListener("invalid", this.boundOnInvalid)
   }
 
   disconnect() {
     document.removeEventListener("click", this.closeOnOutsideClick)
+    this.inputTarget.removeEventListener("invalid", this.boundOnInvalid)
   }
 
   toggle() {

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
       html.setAttribute("data-leftbar-type", "mobile");
     }
     // Also, if the window is resized, check again
-    window.addEventListener("resize", () => {
+    this.resizeHandler = () => {
       if (window.innerWidth < NARROW_WIDTH) {
         html.setAttribute("data-leftbar-hide", "true");
         html.setAttribute("data-leftbar-type", "mobile");
@@ -18,7 +18,12 @@ export default class extends Controller {
         html.removeAttribute("data-leftbar-hide");
         html.removeAttribute("data-leftbar-type");
       }
-    });
+    };
+    window.addEventListener("resize", this.resizeHandler);
+  }
+
+  disconnect() {
+    window.removeEventListener("resize", this.resizeHandler);
   }
 
   leftbarToggle() {

--- a/app/javascript/controllers/turbo_tabs_controller.js
+++ b/app/javascript/controllers/turbo_tabs_controller.js
@@ -4,18 +4,21 @@ export default class extends Controller {
   static targets = ["tabs", "content"]
 
   connect() {
-    console.log(this.contentTarget)
-    this.tabsTarget.addEventListener("click", (event) => {
+    this.clickHandler = (event) => {
       event.preventDefault()
       this.tabsTarget.querySelectorAll(".tab").forEach((radio) => {
         radio.classList.remove("tab-active")
       })
       event.target.classList.add("tab-active")
-      // Show loading spinner
       this.contentTarget.innerHTML = `<div class="flex items-center justify-center my-6" style="height: 300px;">
         <span class="loading loading-spinner loading-sm"></span>
       </div>`
       this.contentTarget.src = event.target.href
-    })
+    }
+    this.tabsTarget.addEventListener("click", this.clickHandler)
+  }
+
+  disconnect() {
+    this.tabsTarget.removeEventListener("click", this.clickHandler)
   }
 }

--- a/app/javascript/controllers/yaml_autocomplete_controller.js
+++ b/app/javascript/controllers/yaml_autocomplete_controller.js
@@ -22,10 +22,18 @@ export default class extends YamlEditorController {
       this.fetchSchema(this.chartUrlValue, this.versionValue)
     } else if (this.hasChartUrlInputIdValue) {
       this.chartUrlInput = document.getElementById(this.chartUrlInputIdValue)
-      this.chartUrlInput.addEventListener('change', (e) => {
+      this.chartUrlChangeHandler = (e) => {
         this.fetchSchema(e.target.value)
-      })
+      }
+      this.chartUrlInput.addEventListener('change', this.chartUrlChangeHandler)
     }
+  }
+
+  disconnect() {
+    if (this.chartUrlInput && this.chartUrlChangeHandler) {
+      this.chartUrlInput.removeEventListener('change', this.chartUrlChangeHandler)
+    }
+    super.disconnect()
   }
 
   // version is only null for new add-ons, in which case it fetches the latest


### PR DESCRIPTION
## Summary
- **10 Stimulus controllers** had missing or broken cleanup in `disconnect()`, causing event listeners, intervals, and chart instances to accumulate on every Turbo navigation
- The worst offender was `progress_progressing_controller` running a `setInterval` every **15ms** that was never cleared — stacking infinitely
- Fixed the common `.bind()` antipattern where `removeEventListener` silently fails because each `.bind()` call creates a new function reference

## Changes
| Controller | Fix |
|---|---|
| `progress_progressing` | Store and clear 15ms `setInterval` |
| `chart` | Destroy `ApexCharts` instance on disconnect |
| `theme` | Store and remove `window.resize` listener |
| `logs` | Remove `turbo:frame-load` listener on disconnect |
| `global_search` | Cache `.bind()` ref so `removeEventListener` works |
| `buildpack_fields` | Cache `.bind()` ref so `removeEventListener` works |
| `rich_select` | Remove `invalid` listener on disconnect |
| `turbo_tabs` | Add missing `disconnect()`, remove stale `console.log` |
| `git_select_repository` | Add missing `disconnect()` for scroll listener |
| `yaml_autocomplete` | Remove `change` listener, call `super.disconnect()` |

## Test plan
- [ ] Navigate between pages with active progress bars (build/deploy in progress) — verify no runaway intervals in DevTools Performance tab
- [ ] Visit cluster metrics charts, navigate away, check no detached DOM nodes in Memory snapshot
- [ ] Open/close logs page repeatedly, verify listener count stays stable
- [ ] Use global search (Cmd+K) across navigations, verify single keydown listener