### PR TITLE
protect onboarding routes when user already exists

### DIFF
--- a/app/controllers/local/onboarding_controller.rb
+++ b/app/controllers/local/onboarding_controller.rb
@@ -1,6 +1,7 @@
 class Local::OnboardingController < ApplicationController
   layout "homepage"
   skip_before_action :authenticate_user!
+  before_action :redirect_if_onboarded
 
   def index
     @in_cluster = K8::Connection.in_cluster?
@@ -38,6 +39,10 @@ class Local::OnboardingController < ApplicationController
   end
 
   private
+
+  def redirect_if_onboarded
+    redirect_to new_user_session_path if User.exists?
+  end
 
   def fetch_in_cluster_info
     cluster = Cluster.new(options: { "in_cluster" => true })

--- a/spec/requests/local/onboarding_controller_spec.rb
+++ b/spec/requests/local/onboarding_controller_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe "Local::Onboarding", type: :request do
 
   describe "redirect_if_onboarded" do
     context "when no users exist" do
-      before { User.delete_all }
-
       it "allows access to the onboarding page" do
         allow(K8::Connection).to receive(:in_cluster?).and_return(false)
         get local_onboarding_index_path

--- a/spec/requests/local/onboarding_controller_spec.rb
+++ b/spec/requests/local/onboarding_controller_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "Local::Onboarding", type: :request do
+  before do
+    allow(Rails.application.config).to receive(:local_mode).and_return(true)
+    Rails.application.reload_routes!
+  end
+
+  after do
+    allow(Rails.application.config).to receive(:local_mode).and_call_original
+    Rails.application.reload_routes!
+  end
+
+  describe "redirect_if_onboarded" do
+    context "when no users exist" do
+      before { User.delete_all }
+
+      it "allows access to the onboarding page" do
+        allow(K8::Connection).to receive(:in_cluster?).and_return(false)
+        get local_onboarding_index_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "allows access to the create action" do
+        post local_onboarding_index_path, params: { onboarding_method: "invalid" }
+        expect(response).to redirect_to(local_onboarding_index_path)
+      end
+    end
+
+    context "when a user already exists" do
+      before { create(:account) }
+
+      it "redirects index to sign-in" do
+        get local_onboarding_index_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "redirects create to sign-in" do
+        post local_onboarding_index_path, params: { onboarding_method: "normal" }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it "redirects account_select to sign-in" do
+        get account_select_local_onboarding_index_path
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a `before_action` to the onboarding controller that redirects to sign-in if any user exists in the database
- Prevents re-running onboarding (index, create, account_select) on an already set up instance

## Test plan
- [ ] Fresh install with no users: onboarding page loads normally
- [ ] After onboarding completes: visiting `/local/onboarding` redirects to sign-in
- [ ] POST to `/local/onboarding` with existing users returns redirect, not a new account