### PR TITLE
Replace example.com with your-domain.com in helm install

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,7 +3,7 @@ class StaticController < ApplicationController
   MAC_INSTALL_SCRIPT = "brew tap CanineHQ/canine && brew install canine"
   MAC_START_SCRIPT = "canine local start"
   HELM_REPO_SCRIPT = "helm repo add canine https://caninehq.github.io/canine && helm repo update"
-  HELM_INSTALL_SCRIPT = "helm install canine canine/canine \\\n  --namespace canine \\\n  --create-namespace \\\n  --set ingress.enabled=true \\\n  --set ingress.hostname=canine.example.com \\\n  --set canine.acmeEmail=you@example.com"
+  HELM_INSTALL_SCRIPT = "helm install canine canine/canine \\\n  --namespace canine \\\n  --create-namespace \\\n  --set ingress.enabled=true \\\n  --set ingress.hostname=canine.your-domain.com \\\n  --set canine.acmeEmail=you@your-domain.com"
   skip_before_action :authenticate_user!
   ILLUSTRATIONS = [
     {


### PR DESCRIPTION
## Summary
- Replace `example.com` with `your-domain.com` in the helm install example command
- `example.com` is IANA-reserved and Let's Encrypt won't issue certificates for it, making the example misleading

## Test plan
- [ ] Verify the helm install command renders correctly on the self-hosted page

🤖 Generated with [Claude Code](https://claude.com/claude-code)