### PR TITLE
Skip installing cert-manager and traefik when already present

### DIFF
--- a/app/actions/clusters/sync_packages.rb
+++ b/app/actions/clusters/sync_packages.rb
@@ -7,11 +7,12 @@ class Clusters::SyncPackages
     user = context.user
 
     connection = K8::Connection.new(cluster, user)
-    kubectl = K8::Kubectl.new(connection, Cli::RunAndLog.new(cluster))
+    kubectl = K8::Kubectl.new(connection)
 
     cluster.info("Syncing package statuses...", color: :yellow)
 
     ClusterPackage.definitions.each do |definition|
+      cluster.info("Checking for #{definition['display_name']}...", color: :yellow)
       package = cluster.cluster_packages.find_by(name: definition["name"])
       check_package = package || cluster.cluster_packages.build(name: definition["name"])
       found = check_package.installer.installed?(kubectl)

--- a/app/models/cluster_package/installer/cert_manager.rb
+++ b/app/models/cluster_package/installer/cert_manager.rb
@@ -1,10 +1,22 @@
 class ClusterPackage::Installer::CertManager < ClusterPackage::Installer::Base
   def install!(kubectl)
+    if cert_manager_present?(kubectl)
+      package.cluster.info("cert-manager already installed, skipping", color: :yellow)
+      return
+    end
+
     install_helm(kubectl)
     install_acme_issuer(kubectl)
   end
 
   private
+
+  def cert_manager_present?(kubectl)
+    kubectl.(%w[get crd certificates.cert-manager.io])
+    true
+  rescue Cli::CommandFailedError
+    false
+  end
 
   def install_acme_issuer(kubectl)
     cluster = kubectl.connection.cluster

--- a/app/models/cluster_package/installer/traefik_ingress.rb
+++ b/app/models/cluster_package/installer/traefik_ingress.rb
@@ -1,2 +1,19 @@
 class ClusterPackage::Installer::TraefikIngress < ClusterPackage::Installer::Base
+  def install!(kubectl)
+    if traefik_present?(kubectl)
+      package.cluster.info("Traefik already installed, skipping", color: :yellow)
+      return
+    end
+
+    super
+  end
+
+  private
+
+  def traefik_present?(kubectl)
+    kubectl.(%w[get ingressclass traefik])
+    true
+  rescue Cli::CommandFailedError
+    false
+  end
 end

--- a/spec/actions/clusters/sync_packages_spec.rb
+++ b/spec/actions/clusters/sync_packages_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe Clusters::SyncPackages do
+  let(:account) { create(:account) }
+  let(:cluster) { create(:cluster, account: account) }
+  let(:user) { create(:user) }
+  let(:connection) { instance_double(K8::Connection) }
+  let(:kubectl) { instance_double(K8::Kubectl) }
+
+  before do
+    allow(K8::Connection).to receive(:new).with(cluster, user).and_return(connection)
+    allow(K8::Kubectl).to receive(:new).with(connection).and_return(kubectl)
+    allow(cluster).to receive(:info)
+    allow(cluster).to receive(:success)
+  end
+
+  def stub_installed(package_name, detected:)
+    installer = instance_double(ClusterPackage::Installer::Base)
+    allow(installer).to receive(:installed?).with(kubectl).and_return(detected)
+    allow_any_instance_of(ClusterPackage).to receive(:installer).and_wrap_original do |original, *args|
+      pkg = original.receiver
+      pkg.name == package_name ? installer : original.call(*args)
+    end
+    installer
+  end
+
+  def stub_all_not_installed
+    allow_any_instance_of(ClusterPackage::Installer::Base).to receive(:installed?).with(kubectl).and_return(false)
+  end
+
+  describe "does not create packages that are not detected" do
+    it "does not create cluster_package records when nothing is found on the cluster" do
+      stub_all_not_installed
+      expect {
+        described_class.execute(cluster: cluster, user: user)
+      }.not_to change { cluster.cluster_packages.count }
+    end
+  end
+
+  describe "creates packages that are detected externally" do
+    it "creates a cluster_package record when detected on the cluster" do
+      stub_all_not_installed
+      stub_installed("traefik-ingress", detected: true)
+
+      expect {
+        described_class.execute(cluster: cluster, user: user)
+      }.to change { cluster.cluster_packages.where(name: "traefik-ingress").count }.from(0).to(1)
+
+      package = cluster.cluster_packages.find_by(name: "traefik-ingress")
+      expect(package).to be_installed
+      expect(package.installed_at).to be_present
+    end
+  end
+
+  describe "updates existing packages" do
+    it "marks a pending package as installed when detected" do
+      package = create(:cluster_package, cluster: cluster, name: "traefik-ingress", status: :pending)
+      stub_all_not_installed
+      stub_installed("traefik-ingress", detected: true)
+
+      described_class.execute(cluster: cluster, user: user)
+
+      expect(package.reload).to be_installed
+    end
+
+    it "marks an installed package as uninstalled when not detected" do
+      package = create(:cluster_package, cluster: cluster, name: "traefik-ingress", status: :installed)
+      stub_all_not_installed
+
+      described_class.execute(cluster: cluster, user: user)
+
+      expect(package.reload).to be_uninstalled
+    end
+
+    it "does not touch an already-installed package that is still detected" do
+      package = create(:cluster_package, cluster: cluster, name: "traefik-ingress", status: :installed, installed_at: 1.day.ago)
+      stub_all_not_installed
+      stub_installed("traefik-ingress", detected: true)
+
+      expect {
+        described_class.execute(cluster: cluster, user: user)
+      }.not_to change { package.reload.updated_at }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Detect cert-manager via its CRD (`certificates.cert-manager.io`) and traefik via its IngressClass before installing, so clusters that already have these (e.g. via the Canine helm chart) don't get duplicate installs
- Add per-package "Checking for..." log lines during sync for better visibility into what's being checked
- Add spec for `SyncPackages` covering detection, creation, and status transitions

## Test plan
- [x] `bundle exec rspec spec/actions/clusters/sync_packages_spec.rb` passes
- [ ] Verify on a cluster with Canine helm chart that cert-manager and traefik are skipped
- [ ] Verify on a fresh cluster that cert-manager and traefik still install normally