### PR TITLE
Fix conditional TLS and PostgreSQL init script

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -13,10 +13,12 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
+  {{- if index .Values "cert-manager" "enabled" }}
   tls:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
       secretName: canine-tls
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.hostname | quote }}
       http:

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ postgresql:
   # See: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
   initdbScripts:
     init.sql: |
-      CREATE DATABASE IF NOT EXISTS canine_development;
+      SELECT 'CREATE DATABASE canine_development' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'canine_development')\gexec
       GRANT ALL PRIVILEGES ON DATABASE canine_development TO postgres;
 
 # Cert Manager configuration (jetstack/cert-manager chart)


### PR DESCRIPTION
## Summary
- Only render the TLS block in the ingress template when cert-manager is enabled, preventing failures when using an ingress without cert-manager
- Fix `initdbScripts` to use PostgreSQL-compatible syntax (`\gexec`) instead of MySQL-style `CREATE DATABASE IF NOT EXISTS`

## Test plan
- [ ] Deploy with `cert-manager.enabled=false` and `ingress.enabled=true` — verify ingress has no TLS block
- [ ] Deploy with both enabled — verify TLS block is present and cert is issued
- [ ] Verify PostgreSQL init script runs without errors on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)