### PR TITLE
Fix pending cluster packages created for missing packages

### DIFF
--- a/app/actions/clusters/sync_packages.rb
+++ b/app/actions/clusters/sync_packages.rb
@@ -14,7 +14,7 @@ class Clusters::SyncPackages
     ClusterPackage.definitions.each do |definition|
       cluster.info("Checking for #{definition['display_name']}...", color: :yellow)
       package = cluster.cluster_packages.find_by(name: definition["name"])
-      check_package = package || cluster.cluster_packages.build(name: definition["name"])
+      check_package = package || ClusterPackage.new(name: definition["name"], cluster: cluster)
       found = check_package.installer.installed?(kubectl)
 
       if found


### PR DESCRIPTION
## Summary
- Changed `cluster.cluster_packages.build(...)` to `ClusterPackage.new(...)` in `SyncPackages` to prevent Rails from auto-saving temporary check objects when the cluster is later saved
- This fixes an issue where packages not present on the cluster (e.g. nginx-ingress, cloudflared) were being created as `pending` records

## Test plan
- [x] Existing specs pass (16/16)
- [ ] Run `Clusters::Install` on a cluster and verify only packages present on the cluster get records
- [ ] Run `Clusters::SyncPackages` separately and verify no new pending records are created