### PR TITLE
fix: don't capitalize user email in deployment events

### DIFF
--- a/app/views/projects/deployments/_event_build_row.html.erb
+++ b/app/views/projects/deployments/_event_build_row.html.erb
@@ -26,7 +26,7 @@
     </div>
   </td>
   <td title="<%= event.user&.name || event.user&.email || "Automated" %>">
-    <div class="text-sm capitalize truncate w-[100px]">
+    <div class="text-sm truncate w-[100px] <%= 'capitalize' unless event.user&.email && event.user&.name.blank? %>">
       <%= event.user&.name || event.user&.email || "Automated" %>
     </div>
   </td>

--- a/app/views/projects/deployments/_event_env_row.html.erb
+++ b/app/views/projects/deployments/_event_env_row.html.erb
@@ -10,7 +10,7 @@
     </div>
   </td>
   <td title="<%= event.user&.name || event.user&.email || "Automated" %>">
-    <div class="text-sm capitalize truncate w-[100px]">
+    <div class="text-sm truncate w-[100px] <%= 'capitalize' unless event.user&.email && event.user&.name.blank? %>">
       <%= event.user&.name || event.user&.email || "Automated" %>
     </div>
   </td>


### PR DESCRIPTION
## Summary
- Remove `capitalize` CSS class from user display in deployment event rows when showing an email address
- Names and "Automated" text still get capitalized, only emails are left as-is

## Test plan
- [ ] Verify deployment events with a user name still show capitalized
- [ ] Verify deployment events with only an email show lowercase
- [ ] Verify "Automated" still shows capitalized