### PR TITLE
fix: align public repository section in repo selection modal

### DIFF
--- a/app/views/integrations/repositories/_modal.html.erb
+++ b/app/views/integrations/repositories/_modal.html.erb
@@ -23,7 +23,7 @@
           </ul>
         </div>
 
-        <div class="mt-6 p-4 rounded-lg">
+        <div class="mt-6 rounded-lg">
           <h3 class="text-lg font-semibold mb-2">Public Repository</h3>
           <p class="mb-4">Use a public repository by entering the URL below. Features like PR Previews and Auto-Deploy are not available if the repository has not been configured for Canine.</p>
           <div class="flex gap-4">


### PR DESCRIPTION
## Summary
- Removed extra `p-4` padding from the public repository container in the repository selection modal that caused it to be misaligned with the rest of the modal content

## Test plan
- [ ] Open the repository selection modal and verify the "Public Repository" section aligns with the content above it

🤖 Generated with [Claude Code](https://claude.com/claude-code)