### PR TITLE
fix: remove extra quotes wrapping build arg values

### DIFF
--- a/app/services/builders/frontends/dockerfile_builder.rb
+++ b/app/services/builders/frontends/dockerfile_builder.rb
@@ -35,7 +35,7 @@ class Builders::Frontends::DockerfileBuilder
 
     # Add environment variables to the build command
     project.environment_variables.each do |envar|
-      docker_build_command.push("--build-arg", "#{envar.name}=\"#{envar.value}\"")
+      docker_build_command.push("--build-arg", "#{envar.name}=#{envar.value}")
     end
 
     docker_build_command.push("--push")


### PR DESCRIPTION
## Summary
- Build args in `DockerfileBuilder` were being wrapped in literal quotes (`\"value\"`), causing values like `https://staging.palmoslabs.com` to arrive in the Docker build as `"https://staging.palmoslabs.com"` with quotes as part of the value
- Since the command is passed as an array to `Open3.popen3`, no shell quoting is needed — Ruby handles argument boundaries directly
- This matches the existing behavior in `BuildCloud` which already passes build args without extra quotes

## Test plan
- [ ] Deploy a project with environment variables containing URLs and verify they no longer have surrounding quotes in the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)