### PR TITLE
fix: discover ingress controller across all namespaces by label

### DIFF
--- a/app/services/k8/stateless/ingress.rb
+++ b/app/services/k8/stateless/ingress.rb
@@ -36,11 +36,13 @@ class K8::Stateless::Ingress < K8::Base
     results['items'].find { |r| r['metadata']['name'] == "#{@service.project.namespace}-ingress" }
   end
 
-  INGRESS_SERVICE_NAMES = %w[traefik ingress-nginx-controller].freeze
+  INGRESS_APP_LABELS = %w[traefik ingress-nginx].freeze
 
   def self.hostname(client)
-    services = client.get_services
-    service = INGRESS_SERVICE_NAMES.lazy.filter_map { |name| services.find { |s| s['metadata']['name'] == name } }.first
+    services = client.get_services(namespace: nil).select { |s| s.spec.type == "LoadBalancer" }
+    service = INGRESS_APP_LABELS.lazy.filter_map { |label|
+      services.find { |s| s.metadata.labels&.[]("app.kubernetes.io/name") == label }
+    }.first
 
     if service.nil?
       raise "No ingress controller service found"


### PR DESCRIPTION
## Summary
- Ingress IP lookup now searches across all namespaces instead of just the default namespace
- Matches ingress controller services by `app.kubernetes.io/name` label (`traefik`, `ingress-nginx`) instead of exact service name
- Filters to `LoadBalancer` type services for more precise matching
- Fixes cases where the service has a Helm release prefix (e.g. `canine-traefik` instead of `traefik`)

## Test plan
- [ ] Verify DNS Type/Value column on `/projects/:id/services/` correctly resolves the ingress IP for clusters with prefixed traefik service names

🤖 Generated with [Claude Code](https://claude.com/claude-code)