### PR TITLE
fix: retry helm uninstall in destroy job before continuing

### DIFF
--- a/app/jobs/projects/destroy_job.rb
+++ b/app/jobs/projects/destroy_job.rb
@@ -1,10 +1,13 @@
 class Projects::DestroyJob < ApplicationJob
+  UNINSTALL_RETRIES = 3
+  UNINSTALL_RETRY_INTERVAL = 5
+
   def perform(project, user)
     project.destroying!
 
     DevelopmentEnvironments::Destroy.execute(project:)
 
-    uninstall_service_class(project).new(project, user).call
+    uninstall_with_retries(project, user)
 
     cleanup_auto_managed_domains(project)
     remove_github_webhook(project) if should_remove_webhook?(project)
@@ -12,6 +15,21 @@ class Projects::DestroyJob < ApplicationJob
   end
 
   private
+
+  def uninstall_with_retries(project, user)
+    attempts = 0
+    begin
+      attempts += 1
+      uninstall_service_class(project).new(project, user).call
+    rescue Cli::CommandFailedError => e
+      if attempts < UNINSTALL_RETRIES
+        Rails.logger.warn("Uninstall attempt #{attempts}/#{UNINSTALL_RETRIES} failed for '#{project.name}': #{e.message}. Retrying in #{attempts * 5}s...")
+        sleep(attempts * UNINSTALL_RETRY_INTERVAL)
+        retry
+      end
+      Rails.logger.error("Uninstall failed after #{UNINSTALL_RETRIES} attempts for '#{project.name}': #{e.message}. Continuing with destroy.")
+    end
+  end
 
   def uninstall_service_class(project)
     deployment_method = project.deployment_configuration&.deployment_method || "legacy"


### PR DESCRIPTION
## Summary
- `Projects::DestroyJob` now retries helm uninstall up to 3 times with increasing backoff (5s, 10s)
- If all retries fail, logs the error and continues with the rest of the cleanup (domain DNS, webhooks, `project.destroy!`) instead of raising
- Fixes intermittent `Cli::CommandFailedError` during project destruction that would leave projects stuck in a `destroying` state

## Test plan
- [ ] Destroy a project successfully — should work as before
- [ ] If helm uninstall fails transiently, it should retry and eventually succeed or continue with cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)