### PR TITLE
Disable sign-up for self-hosted and warn about example.com emails

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   layout 'homepage', only: [ :new, :create ]
+  before_action :disable_registration_for_self_hosted
 
   def create
     ActiveRecord::Base.transaction do
@@ -13,6 +14,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   protected
+
+  def disable_registration_for_self_hosted
+    return if Rails.application.config.cloud_mode
+
+    redirect_to new_user_session_path, alert: "Sign up is disabled."
+  end
+
    def update_resource(resource, params)
     if account_update_params[:password].blank?
       params.delete("password")

--- a/app/javascript/controllers/email_validation_controller.js
+++ b/app/javascript/controllers/email_validation_controller.js
@@ -1,16 +1,21 @@
 import { Controller } from "@hotwired/stimulus"
 
+const BANNED_DOMAINS = ["example.com", "example.org", "example.net", "test.com"]
+
 export default class extends Controller {
-  static targets = ["input", "warning"]
+  static targets = ["input"]
+
+  connect() {
+    this.warning = document.createElement("p")
+    this.warning.className = "text-warning text-sm mt-1 hidden"
+    this.warning.textContent = "Avoid using this domain — Let's Encrypt will reject certificate requests for it."
+    this.inputTarget.parentNode.appendChild(this.warning)
+  }
 
   validate() {
-    const email = this.inputTarget.value
-    const domain = email.split("@")[1] || ""
+    const domain = (this.inputTarget.value.split("@")[1] || "").toLowerCase()
+    const banned = BANNED_DOMAINS.some(d => domain === d || domain.endsWith(`.${d}`))
 
-    if (domain.endsWith("example.com")) {
-      this.warningTarget.classList.remove("hidden")
-    } else {
-      this.warningTarget.classList.add("hidden")
-    }
+    this.warning.classList.toggle("hidden", !banned)
   }
 }

--- a/app/javascript/controllers/email_validation_controller.js
+++ b/app/javascript/controllers/email_validation_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "warning"]
+
+  validate() {
+    const email = this.inputTarget.value
+    const domain = email.split("@")[1] || ""
+
+    if (domain.endsWith("example.com")) {
+      this.warningTarget.classList.remove("hidden")
+    } else {
+      this.warningTarget.classList.add("hidden")
+    }
+  }
+}

--- a/app/views/local/onboarding/_normal.html.erb
+++ b/app/views/local/onboarding/_normal.html.erb
@@ -22,16 +22,20 @@
       label: "Admin User",
       description: "Create the first admin user for this account. (You can configure SSO later.)"
     )) do %>
-      <div class="form-group">
+      <div class="form-group" data-controller="email-validation">
         <%= form.label :email, "Email" %>
         <%= form.email_field(
           :email,
-          placeholder: "admin@example.com",
+          placeholder: "admin@yourdomain.com",
           name: "user[email]",
           inputmode: "email",
           class: "input input-bordered w-full",
           required: true,
+          data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
+        <p class="text-warning text-sm mt-1 hidden" data-email-validation-target="warning">
+          Avoid using example.com — Let's Encrypt will reject certificate requests for this domain.
+        </p>
       </div>
       <div class="form-group" data-controller="toggle-password">
         <%= form.label :password, "Password" %>

--- a/app/views/local/onboarding/_normal.html.erb
+++ b/app/views/local/onboarding/_normal.html.erb
@@ -33,9 +33,6 @@
           required: true,
           data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
-        <p class="text-warning text-sm mt-1 hidden" data-email-validation-target="warning">
-          Avoid using example.com — Let's Encrypt will reject certificate requests for this domain.
-        </p>
       </div>
       <div class="form-group" data-controller="toggle-password">
         <%= form.label :password, "Password" %>

--- a/app/views/local/onboarding/_portainer.html.erb
+++ b/app/views/local/onboarding/_portainer.html.erb
@@ -32,9 +32,6 @@
           required: true,
           data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
-        <p class="text-warning text-sm mt-1 hidden" data-email-validation-target="warning">
-          Avoid using example.com — Let's Encrypt will reject certificate requests for this domain.
-        </p>
       </div>
       <div class="form-group" data-controller="toggle-password">
         <%= form.label :password, "Password" %>

--- a/app/views/local/onboarding/_portainer.html.erb
+++ b/app/views/local/onboarding/_portainer.html.erb
@@ -21,16 +21,20 @@
       label: "Admin User",
       description: "Create the first admin user for this account. (You can configure SSO later.)"
     )) do %>
-      <div class="form-group">
+      <div class="form-group" data-controller="email-validation">
         <%= form.label :email, "Email" %>
         <%= form.email_field(
           :email,
-          placeholder: "admin@example.com",
+          placeholder: "admin@yourdomain.com",
           name: "user[email]",
           inputmode: "email",
           class: "input input-bordered w-full",
           required: true,
+          data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
+        <p class="text-warning text-sm mt-1 hidden" data-email-validation-target="warning">
+          Avoid using example.com — Let's Encrypt will reject certificate requests for this domain.
+        </p>
       </div>
       <div class="form-group" data-controller="toggle-password">
         <%= form.label :password, "Password" %>

--- a/app/views/local/onboarding/_rancher.html.erb
+++ b/app/views/local/onboarding/_rancher.html.erb
@@ -32,9 +32,6 @@
           required: true,
           data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
-        <p class="text-warning text-sm mt-1 hidden" data-email-validation-target="warning">
-          Avoid using example.com — Let's Encrypt will reject certificate requests for this domain.
-        </p>
       </div>
       <div class="form-group" data-controller="toggle-password">
         <%= form.label :password, "Password" %>

--- a/app/views/local/onboarding/_rancher.html.erb
+++ b/app/views/local/onboarding/_rancher.html.erb
@@ -21,16 +21,20 @@
       label: "Admin User",
       description: "Create the first admin user for this account. (You can configure SSO later.)"
     )) do %>
-      <div class="form-group">
+      <div class="form-group" data-controller="email-validation">
         <%= form.label :email, "Email" %>
         <%= form.email_field(
           :email,
-          placeholder: "admin@example.com",
+          placeholder: "admin@yourdomain.com",
           name: "user[email]",
           inputmode: "email",
           class: "input input-bordered w-full",
           required: true,
+          data: { email_validation_target: "input", action: "input->email-validation#validate" },
         ) %>
+        <p class="text-warning text-sm mt-1 hidden" data-email-validation-target="warning">
+          Avoid using example.com — Let's Encrypt will reject certificate requests for this domain.
+        </p>
       </div>
       <div class="form-group" data-controller="toggle-password">
         <%= form.label :password, "Password" %>


### PR DESCRIPTION
## Summary
- Disable Devise registration in local/cluster mode — the onboarding flow handles first user creation, so sign-up should not be accessible after that
- Change onboarding email placeholder from `example.com` to `yourdomain.com`
- Add Stimulus controller that warns users when they enter an `example.com` email, since Let's Encrypt will reject certificate requests for it

## Test plan
- [ ] In local/cluster mode, visiting `/users/sign_up` redirects to sign-in with "Sign up is disabled."
- [ ] In cloud mode, sign-up still works as before
- [ ] Typing an `example.com` email in onboarding shows the warning message
- [ ] Warning hides when switching to a non-example.com email