### PR TITLE
Fix container registry project links and health checks

### DIFF
--- a/app/jobs/scheduled/check_health_job.rb
+++ b/app/jobs/scheduled/check_health_job.rb
@@ -2,7 +2,7 @@ class Scheduled::CheckHealthJob < ApplicationJob
   queue_as :default
 
   def perform
-    Service.where.not(status: :pending).where.not(service_type: :cron_job).each do |service|
+    Service.where.not(service_type: :cron_job).each do |service|
       check_service_health(service)
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -141,6 +141,20 @@ class Project < ApplicationRecord
     project_credential_provider.nil? || project_credential_provider.provider_id.nil?
   end
 
+  def container_registry_image_url
+    base = repository_base_url.to_s
+    repo = repository_url.to_s
+    if base.include?("docker.io")
+      "https://hub.docker.com/r/#{repo}"
+    else
+      "https://#{base}/#{repo}"
+    end
+  end
+
+  def full_image_name
+    [ repository_base_url, repository_url ].compact_blank.join("/")
+  end
+
   def generate_slug
     self.slug = self.name
     while Project.exists?(slug: self.slug)
@@ -191,7 +205,7 @@ class Project < ApplicationRecord
       if git?
         "https://#{repository_base_url}/#{repository_url}"
       elsif container_registry? && repository_base_url.present?
-        "https://#{repository_base_url}"
+        container_registry_image_url
       else
         "#"
       end

--- a/app/views/projects/_layout.html.erb
+++ b/app/views/projects/_layout.html.erb
@@ -33,7 +33,7 @@
         <% else %>
           <div class="flex flex-row items-center gap-1">
             <iconify-icon icon="logos:docker-icon"></iconify-icon>
-            <span class="underline"><%= project.repository_url %></span>
+            <span class="underline"><%= project.full_image_name %></span>
           </div>
         <% end %>
       <% end %>


### PR DESCRIPTION
## Summary
- Fix `link_to_view` for container registry projects — was linking to just the registry host (e.g. `https://docker.io`), now links to the actual image page (`hub.docker.com/r/...` for Docker Hub, `registry/repo` for others)
- Show full image name (registry + repo) in project layout instead of just the repo path
- Check health of all non-cron services regardless of status

## Test plan
- [ ] Verify container registry project links go to the correct image page on Docker Hub
- [ ] Verify project layout shows the full image name (e.g. `docker.io/adrianmusante/pocketbase`)
- [ ] Verify health checks run for services in all statuses