### PR TITLE
feat: automatic build arguments (GIT_SHA, BUILD_TIMESTAMP)

### DIFF
--- a/app/services/builders/base.rb
+++ b/app/services/builders/base.rb
@@ -27,6 +27,18 @@ class Builders::Base
     end
   end
 
+  # Automatic build arguments injected into every build
+  def automatic_build_args
+    self.class.automatic_build_args(build)
+  end
+
+  def self.automatic_build_args(build)
+    {
+      "GIT_SHA" => build.commit_sha,
+      "BUILD_TIMESTAMP" => Time.current.utc.iso8601
+    }
+  end
+
   def setup
   end
 

--- a/app/services/builders/build_cloud.rb
+++ b/app/services/builders/build_cloud.rb
@@ -43,6 +43,11 @@ module Builders
       command += [ "-t", project.container_image_reference ]
       command += [ "-f", File.join(repository_path, project.build_configuration.dockerfile_path) ]
 
+      # Add automatic build arguments
+      automatic_build_args.each do |name, value|
+        command += [ "--build-arg", "#{name}=#{value}" ]
+      end
+
       # Add build arguments
       project.environment_variables.each do |envar|
         command += [ "--build-arg", "#{envar.name}=#{envar.value}" ]

--- a/app/services/builders/frontends/buildpack_builder.rb
+++ b/app/services/builders/frontends/buildpack_builder.rb
@@ -55,6 +55,11 @@ class Builders::Frontends::BuildpackBuilder
       command += [ "--buildpack", pack.reference ]
     end
 
+    # Add automatic build arguments
+    Builders::Base.automatic_build_args(build).each do |name, value|
+      command += [ "--env", "#{name}=#{value}" ]
+    end
+
     # Add publish flag if supported by driver
     command << "--publish" if publish_during_build?
 

--- a/app/services/builders/frontends/dockerfile_builder.rb
+++ b/app/services/builders/frontends/dockerfile_builder.rb
@@ -33,6 +33,11 @@ class Builders::Frontends::DockerfileBuilder
       "-f", File.join(repository_path, project.build_configuration.dockerfile_path)
     ]
 
+    # Add automatic build arguments
+    Builders::Base.automatic_build_args(build).each do |name, value|
+      docker_build_command.push("--build-arg", "#{name}=#{value}")
+    end
+
     # Add environment variables to the build command
     project.environment_variables.each do |envar|
       docker_build_command.push("--build-arg", "#{envar.name}=#{envar.value}")


### PR DESCRIPTION
## Summary
- Adds `GIT_SHA` and `BUILD_TIMESTAMP` as automatic build arguments injected into every build
- Supported across all three builder types: Dockerfile, BuildCloud, and Buildpacks
- Defined in a shared method on `Builders::Base` to avoid duplication

## Test plan
- [ ] Trigger a Dockerfile build and verify `GIT_SHA` and `BUILD_TIMESTAMP` appear in build args
- [ ] Trigger a BuildCloud build and verify the same
- [ ] Trigger a Buildpack build and verify they are passed as `--env`