### PR TITLE
fix: fan out health checks into individual jobs per service

### DIFF
--- a/app/jobs/check_service_health_job.rb
+++ b/app/jobs/check_service_health_job.rb
@@ -1,0 +1,21 @@
+class CheckServiceHealthJob < ApplicationJob
+  queue_as :default
+
+  def perform(service)
+    connection = K8::Connection.new(service.project, nil, allow_anonymous: true)
+    kubectl = K8::Kubectl.new(connection)
+
+    result = kubectl.call(%w[get deployment] + [ service.name, "-n", service.project.namespace, "-o", "json" ])
+    deployment = JSON.parse(result)
+
+    desired = deployment.dig("spec", "replicas") || 1
+    ready = deployment.dig("status", "readyReplicas") || 0
+
+    service.status = ready >= desired ? :healthy : :unhealthy
+    service.last_health_checked_at = DateTime.current
+    service.save
+  rescue StandardError => e
+    Rails.logger.warn("Health check failed for #{service.name}: #{e.class} - #{e.message}")
+    service.update(status: :unhealthy, last_health_checked_at: DateTime.current)
+  end
+end

--- a/app/jobs/check_service_health_job.rb
+++ b/app/jobs/check_service_health_job.rb
@@ -1,20 +1,24 @@
 class CheckServiceHealthJob < ApplicationJob
   queue_as :default
 
+  TIMEOUT = 30.seconds
+
   def perform(service)
-    connection = K8::Connection.new(service.project, nil, allow_anonymous: true)
-    kubectl = K8::Kubectl.new(connection)
+    Timeout.timeout(TIMEOUT) do
+      connection = K8::Connection.new(service.project, nil, allow_anonymous: true)
+      kubectl = K8::Kubectl.new(connection)
 
-    result = kubectl.call(%w[get deployment] + [ service.name, "-n", service.project.namespace, "-o", "json" ])
-    deployment = JSON.parse(result)
+      result = kubectl.call(%w[get deployment] + [ service.name, "-n", service.project.namespace, "-o", "json" ])
+      deployment = JSON.parse(result)
 
-    desired = deployment.dig("spec", "replicas") || 1
-    ready = deployment.dig("status", "readyReplicas") || 0
+      desired = deployment.dig("spec", "replicas") || 1
+      ready = deployment.dig("status", "readyReplicas") || 0
 
-    service.status = ready >= desired ? :healthy : :unhealthy
-    service.last_health_checked_at = DateTime.current
-    service.save
-  rescue StandardError => e
+      service.status = ready >= desired ? :healthy : :unhealthy
+      service.last_health_checked_at = DateTime.current
+      service.save
+    end
+  rescue StandardError, Timeout::Error => e
     Rails.logger.warn("Health check failed for #{service.name}: #{e.class} - #{e.message}")
     service.update(status: :unhealthy, last_health_checked_at: DateTime.current)
   end

--- a/app/jobs/scheduled/check_health_job.rb
+++ b/app/jobs/scheduled/check_health_job.rb
@@ -2,28 +2,8 @@ class Scheduled::CheckHealthJob < ApplicationJob
   queue_as :default
 
   def perform
-    Service.where.not(service_type: :cron_job).each do |service|
-      check_service_health(service)
+    Service.where.not(service_type: :cron_job).find_each do |service|
+      CheckServiceHealthJob.perform_later(service)
     end
-  end
-
-  private
-
-  def check_service_health(service)
-    connection = K8::Connection.new(service.project, nil, allow_anonymous: true)
-    kubectl = K8::Kubectl.new(connection)
-
-    result = kubectl.call(%w[get deployment] + [ service.name, "-n", service.project.namespace, "-o", "json" ])
-    deployment = JSON.parse(result)
-
-    desired = deployment.dig("spec", "replicas") || 1
-    ready = deployment.dig("status", "readyReplicas") || 0
-
-    service.status = ready >= desired ? :healthy : :unhealthy
-    service.last_health_checked_at = DateTime.current
-    service.save
-  rescue StandardError => e
-    Rails.logger.warn("Health check failed for #{service.name}: #{e.class} - #{e.message}")
-    service.update(status: :unhealthy, last_health_checked_at: DateTime.current)
   end
 end

--- a/spec/jobs/check_service_health_job_spec.rb
+++ b/spec/jobs/check_service_health_job_spec.rb
@@ -41,5 +41,14 @@ RSpec.describe CheckServiceHealthJob do
 
       expect(service.reload).to be_unhealthy
     end
+
+    it 'marks service as unhealthy when check times out' do
+      service = create(:service, :web_service, project: project, status: :healthy)
+      allow(kubectl).to receive(:call).and_raise(Timeout::Error.new("execution expired"))
+
+      described_class.new.perform(service)
+
+      expect(service.reload).to be_unhealthy
+    end
   end
 end

--- a/spec/jobs/check_service_health_job_spec.rb
+++ b/spec/jobs/check_service_health_job_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe CheckServiceHealthJob do
+  let(:project) { create(:project) }
+  let(:kubectl) { instance_double(K8::Kubectl) }
+
+  before do
+    allow(K8::Connection).to receive(:new).and_return(double("connection"))
+    allow(K8::Kubectl).to receive(:new).and_return(kubectl)
+  end
+
+  def deployment_json(desired:, ready:)
+    { "spec" => { "replicas" => desired }, "status" => { "readyReplicas" => ready } }.to_json
+  end
+
+  describe '#perform' do
+    it 'marks service as healthy when all replicas are ready' do
+      service = create(:service, :web_service, project: project, status: :unhealthy)
+      allow(kubectl).to receive(:call).and_return(deployment_json(desired: 2, ready: 2))
+
+      described_class.new.perform(service)
+
+      expect(service.reload).to be_healthy
+      expect(service.last_health_checked_at).to be_present
+    end
+
+    it 'marks service as unhealthy when ready replicas < desired' do
+      service = create(:service, :web_service, project: project, status: :healthy)
+      allow(kubectl).to receive(:call).and_return(deployment_json(desired: 2, ready: 1))
+
+      described_class.new.perform(service)
+
+      expect(service.reload).to be_unhealthy
+    end
+
+    it 'marks service as unhealthy when kubectl fails' do
+      service = create(:service, :web_service, project: project, status: :healthy)
+      allow(kubectl).to receive(:call).and_raise(StandardError.new("connection refused"))
+
+      described_class.new.perform(service)
+
+      expect(service.reload).to be_unhealthy
+    end
+  end
+end

--- a/spec/jobs/scheduled/check_health_job_spec.rb
+++ b/spec/jobs/scheduled/check_health_job_spec.rb
@@ -1,74 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Scheduled::CheckHealthJob do
-  let(:job) { described_class.new }
   let(:project) { create(:project) }
-  let(:kubectl) { instance_double(K8::Kubectl) }
-
-  before do
-    allow(K8::Connection).to receive(:new).and_return(double("connection"))
-    allow(K8::Kubectl).to receive(:new).and_return(kubectl)
-  end
-
-  def deployment_json(desired:, ready:)
-    { "spec" => { "replicas" => desired }, "status" => { "readyReplicas" => ready } }.to_json
-  end
 
   describe '#perform' do
-    it 'marks service as healthy when all replicas are ready' do
-      service = create(:service, :web_service, project: project, status: :unhealthy)
-      allow(kubectl).to receive(:call).and_return(deployment_json(desired: 2, ready: 2))
+    it 'enqueues a CheckServiceHealthJob for each non-cron service' do
+      web = create(:service, :web_service, project: project)
+      bg = create(:service, :background_service, project: project)
+      create(:service, :cron_job, project: project)
 
-      job.perform
+      expect {
+        described_class.new.perform
+      }.to have_enqueued_job(CheckServiceHealthJob).exactly(2).times
 
-      expect(service.reload).to be_healthy
-      expect(service.last_health_checked_at).to be_present
-    end
-
-    it 'marks service as unhealthy when ready replicas < desired' do
-      service = create(:service, :web_service, project: project, status: :healthy)
-      allow(kubectl).to receive(:call).and_return(deployment_json(desired: 2, ready: 1))
-
-      job.perform
-
-      expect(service.reload).to be_unhealthy
-    end
-
-    it 'marks service as unhealthy when kubectl fails' do
-      service = create(:service, :web_service, project: project, status: :healthy)
-      allow(kubectl).to receive(:call).and_raise(StandardError.new("connection refused"))
-
-      job.perform
-
-      expect(service.reload).to be_unhealthy
-    end
-
-    it 'checks background services too' do
-      service = create(:service, :background_service, project: project, status: :unhealthy)
-      allow(kubectl).to receive(:call).and_return(deployment_json(desired: 1, ready: 1))
-
-      job.perform
-
-      expect(service.reload).to be_healthy
-    end
-
-    it 'skips cron jobs' do
-      service = create(:service, :cron_job, project: project, status: :healthy)
-      allow(kubectl).to receive(:call)
-
-      job.perform
-
-      expect(kubectl).not_to have_received(:call)
-    end
-
-    it 'checks services with pending status' do
-      service = create(:service, :web_service, project: project, status: :pending)
-      allow(kubectl).to receive(:call).and_return('{"spec":{"replicas":1},"status":{"readyReplicas":0}}')
-
-      job.perform
-
-      expect(kubectl).to have_received(:call)
-      expect(service.reload).to be_unhealthy
+      expect(CheckServiceHealthJob).to have_been_enqueued.with(web)
+      expect(CheckServiceHealthJob).to have_been_enqueued.with(bg)
     end
   end
 end


### PR DESCRIPTION
## Summary
- **Scheduled `CheckHealthJob`** now only enqueues individual `CheckServiceHealthJob` jobs instead of running all health checks in a single synchronous loop
- **New `CheckServiceHealthJob`** handles a single service's kubectl health check independently
- Prevents a single slow/hanging kubectl call from blocking all other health checks (was causing jobs to run for 65+ hours)

## Test plan
- [x] Existing health check logic preserved in `CheckServiceHealthJob`
- [x] `CheckHealthJob` spec verifies correct fan-out (enqueues per non-cron service, skips cron jobs)
- [x] `CheckServiceHealthJob` spec covers healthy, unhealthy, and error cases
- [x] All specs passing