### PR TITLE
fix: fan out metrics fetching into individual jobs per cluster

### DIFF
--- a/app/jobs/fetch_cluster_metrics_job.rb
+++ b/app/jobs/fetch_cluster_metrics_job.rb
@@ -1,0 +1,14 @@
+class FetchClusterMetricsJob < ApplicationJob
+  queue_as :default
+
+  TIMEOUT = 30.seconds
+
+  def perform(cluster)
+    Timeout.timeout(TIMEOUT) do
+      connection = K8::Connection.new(cluster, nil, allow_anonymous: true)
+      K8::Metrics::Metrics.call(connection)
+    end
+  rescue StandardError, Timeout::Error => e
+    Rails.logger.error("Error fetching metrics for cluster #{cluster.name}: #{e.class} - #{e.message}")
+  end
+end

--- a/app/jobs/scheduled/fetch_metrics_job.rb
+++ b/app/jobs/scheduled/fetch_metrics_job.rb
@@ -2,11 +2,8 @@ class Scheduled::FetchMetricsJob < ApplicationJob
   queue_as :default
 
   def perform
-    Cluster.running.each do |cluster|
-      connection = K8::Connection.new(cluster, nil, allow_anonymous: true)
-      nodes = K8::Metrics::Metrics.call(connection)
-    rescue => e
-      Rails.logger.error("Error fetching metrics for cluster #{cluster.name}: #{e.message}")
+    Cluster.running.find_each do |cluster|
+      FetchClusterMetricsJob.perform_later(cluster)
     end
   end
 end

--- a/spec/jobs/fetch_cluster_metrics_job_spec.rb
+++ b/spec/jobs/fetch_cluster_metrics_job_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe FetchClusterMetricsJob do
+  let(:cluster) { create(:cluster, status: :running) }
+
+  describe '#perform' do
+    it 'fetches metrics for the cluster' do
+      allow(K8::Connection).to receive(:new).and_return(double("connection"))
+      allow(K8::Metrics::Metrics).to receive(:call)
+
+      described_class.new.perform(cluster)
+
+      expect(K8::Metrics::Metrics).to have_received(:call)
+    end
+
+    it 'logs error and does not raise when metrics call fails' do
+      allow(K8::Connection).to receive(:new).and_return(double("connection"))
+      allow(K8::Metrics::Metrics).to receive(:call).and_raise(StandardError.new("connection refused"))
+
+      expect { described_class.new.perform(cluster) }.not_to raise_error
+    end
+
+    it 'handles timeout without raising' do
+      allow(K8::Connection).to receive(:new).and_return(double("connection"))
+      allow(K8::Metrics::Metrics).to receive(:call).and_raise(Timeout::Error.new("execution expired"))
+
+      expect { described_class.new.perform(cluster) }.not_to raise_error
+    end
+  end
+end

--- a/spec/jobs/scheduled/fetch_metrics_job_spec.rb
+++ b/spec/jobs/scheduled/fetch_metrics_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Scheduled::FetchMetricsJob do
+  describe '#perform' do
+    it 'enqueues a FetchClusterMetricsJob for each running cluster' do
+      running = create(:cluster, status: :running)
+      create(:cluster, status: :initializing)
+
+      expect {
+        described_class.new.perform
+      }.to have_enqueued_job(FetchClusterMetricsJob).with(running).exactly(:once)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- **Scheduled `FetchMetricsJob`** now enqueues a `FetchClusterMetricsJob` per running cluster instead of fetching all metrics in a single synchronous loop
- **New `FetchClusterMetricsJob`** handles a single cluster's metrics fetch with a 30-second timeout
- Same fan-out pattern as #669 for health checks — prevents a single slow/hanging cluster from blocking all metrics collection

## Test plan
- [x] `FetchMetricsJob` spec verifies correct fan-out (enqueues per running cluster, skips non-running)
- [x] `FetchClusterMetricsJob` spec covers success, error, and timeout cases
- [x] All specs passing, rubocop clean