### PR TITLE
fix: update Hetzner pricing to reflect June 2026 increases

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -55,7 +55,7 @@ class StaticController < ApplicationController
     },
     {
       name: "Hetzner",
-      price: 4,
+      price: 6,
       style: "bg-green-400"
     }
   ]

--- a/public/resources/prices.json
+++ b/public/resources/prices.json
@@ -118,26 +118,26 @@
     "canine": true,
     "tiers": [
       {
-        "name": "CX22",
-        "price": 5,
+        "name": "CX23",
+        "price": 6,
         "cpu": 2,
         "memory": 4
       },
       {
-        "name": "CX32",
-        "price": 8,
+        "name": "CX33",
+        "price": 9,
         "cpu": 4,
         "memory": 8
       },
       {
-        "name": "CX42",
-        "price": 18,
+        "name": "CX43",
+        "price": 17,
         "cpu": 8,
         "memory": 16
       },
       {
-        "name": "CX52",
-        "price": 35,
+        "name": "CX53",
+        "price": 32,
         "cpu": 16,
         "memory": 32
       }


### PR DESCRIPTION
## Summary
- Update Hetzner plan names from CX22/32/42/52 to CX23/33/43/53
- Update prices to match post-June 2026 EUR→USD conversions
- Update landing page starting price from $4 to $6

Closes #652