### PR TITLE
fix: allow nested GitLab group paths in repository URL validation

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -86,7 +86,7 @@ class Project < ApplicationRecord
   validates :branch, presence: true
   validates :repository_url, presence: true
   validates :repository_url, format: {
-                              with: /\A[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]\/[a-zA-Z0-9._-]+\z/,
+                              with: /\A[a-zA-Z0-9][a-zA-Z0-9._-]*(\/[a-zA-Z0-9._-]+)+\z/,
                               message: "must be in the format 'owner/repository'"
                             }, if: :git?
   validates :repository_url, format: {

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Project, type: :model do
     end
 
     context 'repository_url format for git projects' do
-      it 'accepts nested GitLab group paths' do
+      it 'accepts nested group paths' do
         project.repository_url = 'group/subgroup/deep/project-name'
         project.valid?
         expect(project.errors[:repository_url]).to be_empty

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    context 'repository_url format for git projects' do
+      it 'accepts nested GitLab group paths' do
+        project.repository_url = 'group/subgroup/deep/project-name'
+        project.valid?
+        expect(project.errors[:repository_url]).to be_empty
+      end
+
+      it 'rejects repository URLs without a slash' do
+        project.repository_url = 'noslash'
+        project.valid?
+        expect(project.errors[:repository_url]).to include("must be in the format 'owner/repository'")
+      end
+    end
+
     context 'when name or namespace is reserved' do
       it 'is not valid when name is reserved' do
         project.name = 'kube-system'


### PR DESCRIPTION
## Summary
- Update repository URL regex to allow multiple path segments (e.g. `group/subgroup/project`)
- Previously only `owner/repo` (single slash) was accepted, rejecting GitLab nested groups

Closes #662